### PR TITLE
Fix type error for unhashable objects in DataFrame

### DIFF
--- a/pandasgui/store.py
+++ b/pandasgui/store.py
@@ -9,6 +9,7 @@ from functools import wraps
 from datetime import datetime
 from pandasgui.utility import get_logger, unique_name
 import os
+import collections
 
 logger = get_logger(__name__)
 
@@ -164,6 +165,16 @@ class PandasGuiDataFrame:
             self.sort_is_ascending = None
 
         self.column_sorted = None
+        self.update()
+
+    @track_history
+    def change_unhashable_cells(self):
+        def change_unhashable_cells_fn(cell):
+            if isinstance(cell, collections.Hashable):
+                return cell
+            else:
+                return str(cell)
+        self.dataframe = self.dataframe.applymap(change_unhashable_cells_fn)
         self.update()
 
     @track_history

--- a/pandasgui/widgets/dataframe_explorer.py
+++ b/pandasgui/widgets/dataframe_explorer.py
@@ -79,17 +79,25 @@ class DataFrameExplorer(QtWidgets.QMainWindow):
         return "DataFrameExplorer"
 
     def make_statistics_tab(self, pgdf: PandasGuiDataFrame):
-        stats_df = pd.DataFrame(
-            {
-                "Type": pgdf.dataframe.dtypes.replace("object", "string").astype(str),
-                "Count": pgdf.dataframe.count(),
-                "N Unique": pgdf.dataframe.nunique(),
-                "Mean": pgdf.dataframe.mean(numeric_only=True),
-                "StdDev": pgdf.dataframe.std(numeric_only=True),
-                "Min": pgdf.dataframe.min(numeric_only=True),
-                "Max": pgdf.dataframe.max(numeric_only=True),
-            }
-        )
+        stats_dict = {
+            "Type": pgdf.dataframe.dtypes.replace("object", "string").astype(str),
+            "Count": pgdf.dataframe.count(),
+            "N Unique": None,
+            "Mean": pgdf.dataframe.mean(numeric_only=True),
+            "StdDev": pgdf.dataframe.std(numeric_only=True),
+            "Min": pgdf.dataframe.min(numeric_only=True),
+            "Max": pgdf.dataframe.max(numeric_only=True),
+        }
+
+        try:
+            stats_dict["N Unique"] = pgdf.dataframe.nunique()
+        except:
+            pgdf.change_unhashable_cells()
+            stats_dict["N Unique"] = pgdf.dataframe.nunique()
+            stats_dict["Type"] = pgdf.dataframe.dtypes.replace("object", "string").astype(str)
+            print("WARNING: found unhashable items in the DataFrame. They have been converted to strings")
+
+        stats_df = pd.DataFrame(stats_dict)
 
         stats_pgdf = PandasGuiDataFrame(stats_df.reset_index())
         w = DataFrameViewer(stats_pgdf)


### PR DESCRIPTION
Instead, when unhashable types are detected, i.e. the 'nunique' function
fails, the objects are replaced with their string representation.
Fixes issue #35 