### PR TITLE
module wordcloud is missing from reqs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ setuptools
 appdirs
 dacite
 IPython
+wordcloud


### PR DESCRIPTION
This fixes bug #77 

`requirements.txt` was missing wordcloud module. This PR adds it.