### PR TITLE
added px groupings for scatter and lines

### DIFF
--- a/pandasgui/widgets/grapher.py
+++ b/pandasgui/widgets/grapher.py
@@ -155,7 +155,7 @@ def clear_layout(layout):
 
 def line(**kwargs):
     key_cols = []
-    for arg in [a for a in ['x', 'color', 'facet_row', 'facet_col'] if a in kwargs.keys()]:
+    for arg in [a for a in ['x', 'color', 'line_dash', 'line_group', 'facet_row', 'facet_col'] if a in kwargs.keys()]:
         key_cols_subset = kwargs[arg]
         if type(key_cols_subset) == list:
             key_cols += key_cols_subset
@@ -226,6 +226,8 @@ schemas = [Schema(name='histogram',
                   args=[ColumnArg(arg_name='x'),
                         ColumnArg(arg_name='y'),
                         ColumnArg(arg_name='color'),
+                        ColumnArg(arg_name='symbol'),
+                        ColumnArg(arg_name='size'),
                         ColumnArg(arg_name='facet_row'),
                         ColumnArg(arg_name='facet_col')],
                   label='Scatter',
@@ -235,6 +237,8 @@ schemas = [Schema(name='histogram',
                   args=[ColumnArg(arg_name='x'),
                         ColumnArg(arg_name='y'),
                         ColumnArg(arg_name='color'),
+                        ColumnArg(arg_name='line_dash'),
+                        ColumnArg(arg_name='line_group'),
                         ColumnArg(arg_name='facet_row'),
                         ColumnArg(arg_name='facet_col')],
                   label='Line',


### PR DESCRIPTION
High dimensional data is difficult to visualize without sufficient visual groupings. This PR improves the situation.

Plotly express `scatter` supports visual facets / grouping through `symbol` and `size`, besides the currently available `color`:
https://plotly.com/python-api-reference/generated/plotly.express.scatter.html

PX `line` also supports `line_dash` as visuals, besides `color`:
https://plotly.com/python-api-reference/generated/plotly.express.line.html

It also supports a `line_group`, allowing to separate time series and other line plots by a column _(where all points belonging to one line are identified by this column, i.e., rainfall at airport X over time)_

This pull request adds support for these to the drag and drop interface.

Ideally, this would also add support for lines with symbol, but as that is not directly supported by Plotly express, it will be a little more involved and will be part of a future PR.