### PR TITLE
Add markers to line plot

### DIFF
--- a/pandasgui/widgets/plotly_viewer.py
+++ b/pandasgui/widgets/plotly_viewer.py
@@ -4,6 +4,7 @@ import tempfile
 
 from plotly.io import to_html
 import plotly.graph_objs as go
+from plotly.validators.scatter.marker import SymbolValidator
 from PyQt5 import QtCore, QtGui, QtWidgets, sip
 from PyQt5.QtCore import Qt
 
@@ -33,6 +34,9 @@ if "PyQt5.QtWebEngineWidgets" not in sys.modules:
 
         app.__init__(sys.argv + ["--ignore-gpu-blacklist", "--enable-gpu-rasterization"])
 
+# Available symbol names for a given version of Plotly
+_extended_symbols = SymbolValidator().values[0::2][1::3]
+plotly_markers = [symbol for symbol in _extended_symbols if symbol[-3:] != "dot"]
 
 class PlotlyViewer(QtWebEngineWidgets.QWebEngineView):
     def __init__(self, fig=None, store=None):


### PR DESCRIPTION
In the previous PR, added a few facets to line plot and scatter. This PR expands on this.

- Added **markers** using `marker_symbol` to line plot and logic to handle it (_not directly supported by Plotly Express_) using the `lines+markers` mode for plotly traces. These markers can be one of (_will cycle through repeatedly_):
![symbols](https://user-images.githubusercontent.com/1105325/106059711-1871d500-60c1-11eb-8143-e53139d03e94.png)
- Optional custom keyword args of `marker_size` and `marker_line_width`, for the line plot
- Added `hover_name` to line plot. It is also used by marker if not explicitly selected by the user. Example with marker for horsepower, and hover showing horsepower at the top:
![line_hover_and_markers](https://user-images.githubusercontent.com/1105325/106060005-84543d80-60c1-11eb-91bf-e25a8643e90b.png)
- Added `hover_name` to scatter plot. Example with builtin dataset:
![scatter_hover_name](https://user-images.githubusercontent.com/1105325/106060113-a8178380-60c1-11eb-870e-88fd3c09fa0e.png)
- Mirrored faceting options to 3d_scatter plot (`symbol`, `size` and `hover_name`). Example with builtin dataset:
![scatter_3d_hover_name](https://user-images.githubusercontent.com/1105325/106060245-c3828e80-60c1-11eb-9daa-1fcd0e8633e3.png)

