### PR TITLE
add and display parquet file

### DIFF
--- a/pandasgui/gui.py
+++ b/pandasgui/gui.py
@@ -241,7 +241,7 @@ class PandasGui(QtWidgets.QMainWindow):
 
     def import_dialog(self):
         dialog = QtWidgets.QFileDialog()
-        paths, _ = dialog.getOpenFileNames(filter="*.csv *.xlsx")
+        paths, _ = dialog.getOpenFileNames(filter="*.csv *.xlsx *.parquet")
         for path in paths:
             self.store.import_file(path)
 

--- a/pandasgui/store.py
+++ b/pandasgui/store.py
@@ -374,6 +374,11 @@ class Store:
             for sheet_name in df_dict.keys():
                 df_name = f"{filename} - {sheet_name}"
                 self.add_dataframe(df_dict[sheet_name], df_name)
+        elif path.endswith(".parquet"):
+            filename = os.path.split(path)[1].split('.parquet')[0]
+            df = pd.read_parquet(path, engine='pyarrow')
+            self.add_dataframe(df, filename)
+
         else:
             logger.warning("Can only import csv / xlsx. Invalid file: " + path)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ appdirs
 dacite
 pynput
 IPython
+pyarrow


### PR DESCRIPTION
add option for open and display a parquet file 
Methods update:
- import_file in the Store Class (for read and transform the parquet file to pandas)
- import_dialog in PandasGui Clas (for open the parquet file)
- maj requirements for import pyarrow