### PR TITLE
Nunique sort

### DIFF
--- a/pandasgui/widgets/dragger.py
+++ b/pandasgui/widgets/dragger.py
@@ -42,7 +42,7 @@ class Dragger(QtWidgets.QWidget):
     finished = QtCore.pyqtSignal()
 
     def __init__(self, sources: List[str],
-                 destinations: List[str], source_types: List[str]):
+                 destinations: List[str], source_nunique: List[str], source_types: List[str]):
         super().__init__()
         self.remembered_values = {}
         self.source_tree_unfiltered = []
@@ -50,6 +50,7 @@ class Dragger(QtWidgets.QWidget):
         # Ensure no duplicates
         assert (len(sources) == len(set(sources)))
         assert (len(destinations) == len(set(destinations)))
+        assert (len(sources) == len(source_nunique))
         assert (len(sources) == len(source_types))
 
         # Custom kwargs dialog
@@ -61,8 +62,8 @@ class Dragger(QtWidgets.QWidget):
 
         # Sources list
         self.source_tree = self.SourceTree(self)
-        self.source_tree.setHeaderLabels(['Name', 'Type'])
-        self.set_sources(sources, source_types)
+        self.source_tree.setHeaderLabels(['Name', '#Unique', 'Type'])
+        self.set_sources(sources, source_nunique, source_types)
         self.source_tree.setSortingEnabled(True)
 
         # Depends on Search Box and Source list
@@ -70,8 +71,9 @@ class Dragger(QtWidgets.QWidget):
 
         # Destinations tree
         self.dest_tree = self.DestinationTree(self)
-        self.dest_tree.setHeaderLabels(['Name', ''])
+        self.dest_tree.setHeaderLabels(['Name', '', ''])
         self.dest_tree.setColumnHidden(1, True)
+        self.dest_tree.setColumnHidden(2, True)
         self.dest_tree.setItemsExpandable(False)
         self.dest_tree.setRootIsDecorated(False)
 
@@ -221,11 +223,11 @@ class Dragger(QtWidgets.QWidget):
 
         return data
 
-    def set_sources(self, sources: List[str], source_types: List[str]):
+    def set_sources(self, sources: List[str], source_nunique: List[str], source_types: List[str]):
 
         for i in range(len(sources)):
             item = QtWidgets.QTreeWidgetItem(self.source_tree,
-                                             [str(sources[i]), str(source_types[i])])
+                                             [str(sources[i]), str(source_nunique[i]), str(source_types[i])])
 
         self.filter()
 
@@ -364,6 +366,7 @@ if __name__ == "__main__":
     app = QApplication(sys.argv)
 
     test = Dragger(sources=pokemon.columns, destinations=["x", "y", "color"],
+                   source_nunique=pokemon.nunique().apply('{: >6}'.format).values,
                    source_types=pokemon.dtypes.values.astype(str))
     test.finished.connect(lambda: print(test.get_data()))
     test.show()

--- a/pandasgui/widgets/grapher.py
+++ b/pandasgui/widgets/grapher.py
@@ -57,7 +57,7 @@ class Grapher(QtWidgets.QWidget):
 
         df = flatten_df(self.pgdf.df)
         self.dragger = Dragger(sources=df.columns, destinations=[],
-                               source_nunique=df.nunique().apply('{: >6}'.format).values,
+                               source_nunique=df.nunique().apply('{: >7}'.format).values,
                                source_types=df.dtypes.values.astype(str))
 
         self.layout = QtWidgets.QGridLayout()

--- a/pandasgui/widgets/grapher.py
+++ b/pandasgui/widgets/grapher.py
@@ -58,6 +58,7 @@ class Grapher(QtWidgets.QWidget):
 
         df = flatten_df(self.pgdf.df)
         self.dragger = Dragger(sources=df.columns, destinations=[],
+                               source_nunique=df.nunique().apply('{: >6}'.format).values,
                                source_types=df.dtypes.values.astype(str))
 
         self.spinner = Spinner()

--- a/pandasgui/widgets/reshaper.py
+++ b/pandasgui/widgets/reshaper.py
@@ -44,6 +44,7 @@ class Reshaper(QtWidgets.QWidget):
 
         df = flatten_df(self.pgdf.df)
         self.dragger = Dragger(sources=df.columns, destinations=[],
+                               source_nunique=df.nunique().apply('{: >6}'.format).values,
                                source_types=df.dtypes.values.astype(str))
 
         self.layout = QtWidgets.QGridLayout()


### PR DESCRIPTION
## Purpose

Added number of unique value column on grapher and reshaper. This allows sorting variables to quickly pick low cardinality (categorical) variables for faceting.

## Implementation limitation

The sorting works on numbers as strings, but the numbers are padded with spaces so the alphabetical sort up/down works. In theory, if there were over 9,999,999 unique values, sort might be off, but `dataframe_viewer` struggles anyway past a few million rows, so in practice that should be fine.

## Visual example
Example using the `mpg` data set:

![sort_by_nunique](https://user-images.githubusercontent.com/1105325/106548181-8f9dd380-64dc-11eb-9a9b-3401eed11759.png)

This addresses one feature mentioned on issue #27