### PR TITLE
Auto complete columns

### DIFF
--- a/pandasgui/constants.py
+++ b/pandasgui/constants.py
@@ -1,6 +1,8 @@
 import os
 from appdirs import user_data_dir
 
+CATEGORICAL_THRESHOLD = 50
+
 LOCAL_DATA_DIR = os.path.join(user_data_dir(), "pandasgui")
 LOCAL_DATASET_DIR = os.path.join(LOCAL_DATA_DIR, "dataset_files")
 

--- a/pandasgui/widgets/filter_viewer.py
+++ b/pandasgui/widgets/filter_viewer.py
@@ -65,9 +65,17 @@ class FilterViewer(QtWidgets.QWidget):
         # autocompletion for QLineEdit
         columns = self.pgdf.df_unfiltered.columns
         valid_values = [f"`{col}`" for col in columns]
+        categoricals = columns[self.pgdf.df_unfiltered.dtypes == "category"]
         low_cardinality = columns[self.pgdf.df_unfiltered.nunique() < CATEGORICAL_THRESHOLD]
-        for col in low_cardinality:
-            in_dataset = [f'"{val}"' for val in self.pgdf.df_unfiltered[col].unique()]
+
+        # make unique the column names
+        all_categoricals = list(set(categoricals) | set(low_cardinality))
+
+        for col in all_categoricals:
+            if col in categoricals:
+                in_dataset = [f'"{val}"' for val in self.pgdf.df_unfiltered[col].cat.categories]
+            else:
+                in_dataset = [f'"{val}"' for val in self.pgdf.df_unfiltered[col].unique()]
             valid_values.extend(in_dataset)
 
         self.completer = Completer(valid_values)


### PR DESCRIPTION
# Purpose

Adding autocompletion to the filter QLineEdit widgets. This is to get feedback. I would think this is better than copy / paste or drag and drop, maybe? If this works ok, I'd like to expand and do proper filtering of valid values based on column in a future PR.

This doesn't really close #88 as I think the column header filtering is probably what a lot of people really want, but that is too much of time budget for me ATM.

# Added:
- constant for max cardinality of categoricals to be included in autocompletion (_should be a user setting..._)
- checkbox below the filter box to enable/disable autocompletion
![backtick_checkbox](https://user-images.githubusercontent.com/1105325/107087343-5198fc00-67c9-11eb-8f86-1ac7d522e09d.png)

- QCompleter based on a list of columns (_backtick delimited_) and values for low cardinality categoricals (_quote delimited_)
- case insensitive suggestions
![all_c_matches](https://user-images.githubusercontent.com/1105325/107087611-b05e7580-67c9-11eb-8823-5493a923ca08.png)

- start with backtick to get list of columns only
![backtick](https://user-images.githubusercontent.com/1105325/107087772-f3b8e400-67c9-11eb-91a6-44f34305b838.png)

- type the numexpr as usual, ie ==, in (), !=, then to select an available value, use quote (")
![quote](https://user-images.githubusercontent.com/1105325/107088093-6d50d200-67ca-11eb-94bb-e4a7329d8fb5.png)

