### PR TITLE
added button and dialog to save html plot

### DIFF
--- a/pandasgui/widgets/dragger.py
+++ b/pandasgui/widgets/dragger.py
@@ -43,6 +43,7 @@ class Schema:
 class Dragger(QtWidgets.QWidget):
     itemDropped = QtCore.pyqtSignal()
     finished = QtCore.pyqtSignal()
+    saving = QtCore.pyqtSignal()
 
     def __init__(self, sources: List[str],
                  destinations: List[str], source_nunique: List[str], source_types: List[str]):
@@ -97,6 +98,7 @@ class Dragger(QtWidgets.QWidget):
         # Buttons
         self.kwargs_button = QtWidgets.QPushButton("Custom Kwargs")
         self.reset_button = QtWidgets.QPushButton("Reset")
+        self.save_html_button = QtWidgets.QPushButton("Save HTML")
         self.finish_button = QtWidgets.QPushButton("Finish")
 
         # Signals
@@ -104,6 +106,7 @@ class Dragger(QtWidgets.QWidget):
         self.dest_tree.itemDoubleClicked.connect(self.handle_double_click)
         self.kwargs_button.clicked.connect(self.custom_kwargs)
         self.reset_button.clicked.connect(self.reset)
+        self.save_html_button.clicked.connect(self.save_html)
         self.finish_button.clicked.connect(self.finish)
 
         # Layout
@@ -114,6 +117,7 @@ class Dragger(QtWidgets.QWidget):
         self.button_layout = QtWidgets.QHBoxLayout()
         self.button_layout.addWidget(self.kwargs_button)
         self.button_layout.addWidget(self.reset_button)
+        self.button_layout.addWidget(self.save_html_button)
         self.button_layout.addWidget(self.finish_button)
 
         self.main_layout = QtWidgets.QGridLayout()
@@ -170,6 +174,9 @@ class Dragger(QtWidgets.QWidget):
 
     def finish(self):
         self.finished.emit()
+
+    def save_html(self):
+        self.saving.emit()
 
     def apply_tree_settings(self):
         # Destination tree

--- a/pandasgui/widgets/grapher.py
+++ b/pandasgui/widgets/grapher.py
@@ -74,6 +74,7 @@ class Grapher(QtWidgets.QWidget):
         # Signals
         self.plot_type_picker.itemSelectionChanged.connect(self.on_type_changed)
         self.dragger.finished.connect(self.on_dragger_finished)
+        self.dragger.saving.connect(self.on_dragger_saving)
 
         # Initial selection
         self.plot_type_picker.setSelectionMode(QtWidgets.QAbstractItemView.SingleSelection)
@@ -93,6 +94,19 @@ class Grapher(QtWidgets.QWidget):
         arg_list = [arg.arg_name for arg in self.current_schema.args]
 
         self.dragger.set_destinations(arg_list)
+
+    def on_dragger_saving(self):
+        options = QtWidgets.QFileDialog.Options()
+        # using native widgets so it matches the PNG download button
+
+        filename, _ = QtWidgets.QFileDialog().getSaveFileName(self, "Save plot to", "", "HTML Files (*.html)",
+                                                              options=options)
+        if filename:
+            if filename[-5:] != ".html":
+                filename += ".html"
+            self.fig.write_html(filename)
+            self.pgdf.add_history_item("Grapher",
+                                       f"fig.write_html('{filename})'")
 
     def on_dragger_finished(self):
         # df = flatten_df(self.pgdf.df)


### PR DESCRIPTION
## Saving of Plotly chart to html

Added button between `Reset` and `Finish`:

![save_html](https://user-images.githubusercontent.com/1105325/108282886-602fcd80-7150-11eb-8213-866c3420c9c3.jpg)

Added native dialog with *.html filter and adding extension when saving if not specified:

![native](https://user-images.githubusercontent.com/1105325/108282936-73429d80-7150-11eb-939f-a4f16025bd36.jpg)

Added code export entry:
![code_export](https://user-images.githubusercontent.com/1105325/108282988-8b1a2180-7150-11eb-9785-8018ceec1860.jpg)
