### PR TITLE
New settings for custom kwargs

### DIFF
--- a/pandasgui/constants.py
+++ b/pandasgui/constants.py
@@ -4,6 +4,7 @@ from appdirs import user_data_dir
 CATEGORICAL_THRESHOLD = 50
 DEFAULT_TITLE_FORMAT = "{name}: {title_columns}{title_dimensions}{names}{title_y}{title_z}{over_by}{title_x} {selection}<br>"\
                        "<sub>{groupings}{filters} {title_trendline}</sub>"
+RENDER_MODE = 'auto'
 
 LOCAL_DATA_DIR = os.path.join(user_data_dir(), "pandasgui")
 LOCAL_DATASET_DIR = os.path.join(LOCAL_DATA_DIR, "dataset_files")

--- a/pandasgui/constants.py
+++ b/pandasgui/constants.py
@@ -2,6 +2,8 @@ import os
 from appdirs import user_data_dir
 
 CATEGORICAL_THRESHOLD = 50
+DEFAULT_TITLE_FORMAT = "{name}: {title_columns}{title_dimensions}{names}{title_y}{title_z}{over_by}{title_x} {selection}<br>"\
+                       "<sub>{groupings}{filters} {title_trendline}</sub>"
 
 LOCAL_DATA_DIR = os.path.join(user_data_dir(), "pandasgui")
 LOCAL_DATASET_DIR = os.path.join(LOCAL_DATA_DIR, "dataset_files")

--- a/pandasgui/store.py
+++ b/pandasgui/store.py
@@ -10,7 +10,7 @@ from functools import wraps
 from datetime import datetime
 from pandasgui.utility import unique_name, in_interactive_console, rename_duplicates, refactor_variable, parse_dates, \
     clean_dataframe
-from pandasgui.constants import LOCAL_DATA_DIR, DEFAULT_TITLE_FORMAT
+from pandasgui.constants import LOCAL_DATA_DIR, DEFAULT_TITLE_FORMAT, RENDER_MODE
 import os
 import collections
 from enum import Enum
@@ -60,7 +60,8 @@ class Setting(DictLike):
 
 
 class SettingsStore(DictLike):
-    def __init__(self, editable=False, style="Fusion", block=None, theme=preferences['theme'], title_format=DEFAULT_TITLE_FORMAT):
+    def __init__(self, editable=False, style="Fusion", block=None, theme=preferences['theme'],
+                 title_format=DEFAULT_TITLE_FORMAT, render_mode=RENDER_MODE):
         if block is None:
             if in_interactive_console():
                 # Don't block if in an interactive console (so you can view GUI and still continue running commands)
@@ -97,6 +98,12 @@ class SettingsStore(DictLike):
                                     value=title_format,
                                     description="format string for automatically generated chart title",
                                     dtype=str,
+                                    persist=False)
+
+        self.render_mode = Setting(label="render_mode",
+                                    value=render_mode,
+                                    description="render mode for plotly express charts",
+                                    dtype=Enum("RenderEnum", ['auto', 'webgl', 'svg']),
                                     persist=False)
 
 

--- a/pandasgui/store.py
+++ b/pandasgui/store.py
@@ -10,7 +10,7 @@ from functools import wraps
 from datetime import datetime
 from pandasgui.utility import unique_name, in_interactive_console, rename_duplicates, refactor_variable, parse_dates, \
     clean_dataframe
-from pandasgui.constants import LOCAL_DATA_DIR
+from pandasgui.constants import LOCAL_DATA_DIR, DEFAULT_TITLE_FORMAT
 import os
 import collections
 from enum import Enum
@@ -60,7 +60,7 @@ class Setting(DictLike):
 
 
 class SettingsStore(DictLike):
-    def __init__(self, editable=False, style="Fusion", block=None, theme=preferences['theme']):
+    def __init__(self, editable=False, style="Fusion", block=None, theme=preferences['theme'], title_format=DEFAULT_TITLE_FORMAT):
         if block is None:
             if in_interactive_console():
                 # Don't block if in an interactive console (so you can view GUI and still continue running commands)
@@ -92,6 +92,12 @@ class SettingsStore(DictLike):
                              description="UI theme",
                              dtype=Enum("ThemesEnum", ['light', 'dark', 'classic']),
                              persist=True)
+
+        self.title_format = Setting(label="title_format",
+                                    value=title_format,
+                                    description="format string for automatically generated chart title",
+                                    dtype=str,
+                                    persist=False)
 
 
 @dataclass

--- a/pandasgui/utility.py
+++ b/pandasgui/utility.py
@@ -414,7 +414,7 @@ def eval_title(pgdf, current_schema, kwargs):
         histfunc = kwargs.get("histfunc", "sum" if y else "count")
         if x is None and y:
             y=f"{y} {histfunc}"
-    elif chart == "box":
+    elif chart in ("box", "violin"):
         histfunc = "distribution"
         over_by = " by "
         if x is None and y:

--- a/pandasgui/utility.py
+++ b/pandasgui/utility.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+import datetime
 import logging
 import pandas as pd
 from PyQt5 import QtWidgets
@@ -320,6 +322,183 @@ def flatten_iter(item):
         t.append(item)
 
     return t
+
+
+def active_filters_repr(filters):
+    "string representation of active filter expressions"
+    return ','.join([filter.expr for filter in filters if filter.enabled and filter.failed == False])
+
+
+def remove_units(label):
+    "we do not want to repeat units in the title. It is assumed they are in parenthesis"
+    if type(label) == list and len(label) == 0:
+        return label
+    elif type(label) == list and len(label) == 1:
+        return remove_units(label[0])
+    elif type(label) == list and len(label) > 1:
+        return [remove_units(val) for val in label]
+    try:
+        return label[:label.rindex("(")] if label[-1] == ")" else label
+    except (AttributeError, IndexError, TypeError, ValueError):
+        return label
+
+
+def axis_title_labels(kwargs):
+    "handling of x, y, z and dimentsions, columns / orientation and log scales for all charts"
+    orientation = kwargs.get("orientation")
+    log_x = kwargs.get("log_x", False)
+    log_y = kwargs.get("log_y", False)
+    log_z = kwargs.get("log_z", False)
+
+    title_log_x = "log " if log_x else ""
+    title_log_y = "log " if log_y else ""
+    title_log_z = "log " if log_z else ""
+
+    x = remove_units(kwargs.get("x"))
+    y = remove_units(kwargs.get("y", ""))
+    z = remove_units(kwargs.get("z", ""))
+    dimensions = remove_units(kwargs.get("dimensions", ""))
+    columns = remove_units(kwargs.get("columns", ""))
+
+    if orientation == "h":
+        x, y = y, x
+        title_log_x, title_log_y = title_log_y, title_log_x
+    if x is None:
+        opt_x = x  # wordcloud, pie etc have no x
+    elif type(x) == list:
+        opt_x = [title_log_x + val for val in x]
+    else:
+        opt_x = title_log_x + x
+    if type(y) == list:
+        opt_y = [title_log_y + val for val in y]
+    else:
+        opt_y = title_log_y + y
+    return opt_x, opt_y, title_log_z + z, dimensions, columns
+
+
+def eval_title(pgdf, current_schema, kwargs):
+    """template variable replacement.
+
+    Besides all dragger selections (x, y, z, color etc), and all custom kwargs, extra template variables are:
+
+          date: current datetime
+          filters: active filter expressions, comma delimited
+          title_x: x minus units and with log scale if selected
+          title_y: y minus units and with log scale if selected
+          title_z: z minus units and with log scale if selected
+          title_dimensions: dimensions list minus units
+          title_columns: columns list minus units
+          title_trendline: trendline description
+          vs: when doing a title with x vs y, use {x}{vs}{y}
+          over_by: when doing a title y over x, use {y}{ober_by}{x}. Preferred. for distributions, will use "by"
+          name: dataframe name
+          total: total number of observations
+          subset: observations with active filters applied
+          selection: ready to use string representing {subset} observations of {total}
+          groupings: groupings tied to Legend and not on legend: marker_symbol, line_group, size etc
+    """
+    today = datetime.datetime.now()
+    name = pgdf.name
+    chart = current_schema.name
+    x, y, z, dimensions, columns = axis_title_labels(kwargs)
+
+    # Histograms default to count for aggregation
+    histfunc = ""
+    over_by = " over "
+    vs = " vs "
+    title_trendline = kwargs.get("trendline", "")
+    if title_trendline != "":
+        title_trendline = f"trend lines are <i>{title_trendline}</i>"
+
+    if chart == "histogram":
+        histfunc = kwargs.get("histfunc", "sum" if y else "count")
+        if x is None and y:
+            y=f"{y} {histfunc}"
+    elif chart == "box":
+        histfunc = "distribution"
+        over_by = " by "
+        if x is None and y:
+            y=f"{y} {histfunc}"
+    elif chart == "bar":
+        over_by = " by "
+    elif chart == "density_heatmap":
+        histfunc = kwargs.get("histfunc", "sum")
+        if y and z:
+            y, z = f"binned {histfunc} of {z} for ", y
+        elif y:
+            y = f"binned count of {y}"
+        histfunc = ""
+    elif chart == "density_contour":
+        histfunc = kwargs.get("histfunc", "count")
+        estimation = "estimated density "
+        if y and z:
+            y, z = f"estimated {histfunc} density of {z} for ", y
+        elif y:
+            y = f"estimated count density of {y}"
+        histfunc = ""
+    elif chart =="scatter_3d":
+        if y and z:
+            # need to separate them
+            z = ", " + z
+    elif chart in ("word_cloud", "scatter_matrix", "pie"):
+        x = ""  # else string will evaluate to None
+
+    # filters
+    filters = active_filters_repr(pgdf.filters)
+    if filters != "":
+        filters = "Filters: " + filters
+    total = pgdf.df_unfiltered.shape[0]
+
+    subset = pgdf.df.shape[0]
+    selection = ""
+    groupings = ""
+    sep = ""
+
+    # over / by
+    over_by = f" {histfunc}{over_by}" if x else ""
+    vs = f"{vs} {histfunc}" if y else ""
+
+    # Groupings in Legend
+    if kwargs.get("color") or kwargs.get("symbol"):
+        groupings += "Legend"
+        sep = ", "
+
+    # this one shows on the legend, but is not labeled
+    if kwargs.get("marker_symbol"):
+        groupings += f"{sep}marker={kwargs['marker_symbol']}"
+
+    # next two don't show in the plotly legend, so we need to explicitly add them
+    if "line_group" in kwargs.keys():
+        groupings += f"{sep}line_group={kwargs['line_group']}"
+    if "size" in kwargs.keys():
+        groupings += f"{sep}size={kwargs['size']}"
+    if groupings != "":
+        groupings = "Grouped by " + groupings
+        if filters != "":
+            groupings += " - "
+
+    if subset != total:
+        selection = f"({subset} obs. of {total}) "
+    else:
+        selection = f"({total} obs.)" if chart == "line" else "(all observations)"
+
+    return kwargs["title"].format_map(defaultdict(str,
+                                                  date=today,
+                                                  filters=filters,
+                                                  title_x=x,
+                                                  title_y=y,
+                                                  title_z=z,
+                                                  title_dimensions=dimensions,
+                                                  title_columns=columns,
+                                                  title_trendline=title_trendline,
+                                                  vs=vs,
+                                                  over_by=over_by,
+                                                  name=name,
+                                                  total=total,
+                                                  subset=subset,
+                                                  selection=selection,
+                                                  groupings=groupings,
+                                                  **kwargs))
 
 
 # Make a string from a kwargs dict as they would be displayed when passed to a function

--- a/pandasgui/utility.py
+++ b/pandasgui/utility.py
@@ -390,7 +390,7 @@ def eval_title(pgdf, current_schema, kwargs):
           title_columns: columns list minus units
           title_trendline: trendline description
           vs: when doing a title with x vs y, use {x}{vs}{y}
-          over_by: when doing a title y over x, use {y}{ober_by}{x}. Preferred. for distributions, will use "by"
+          over_by: when doing a title y over x, use {y}{over_by}{x}. Preferred. for distributions, will use "by"
           name: dataframe name
           total: total number of observations
           subset: observations with active filters applied

--- a/pandasgui/widgets/grapher.py
+++ b/pandasgui/widgets/grapher.py
@@ -119,6 +119,11 @@ class Grapher(QtWidgets.QWidget):
             else:
                 kwargs[key] = val
 
+        render_mode = self.pgdf.settings.render_mode.value
+        if kwargs.get("render_mode", "") == "":
+            if self.current_schema.name in ("line", "line_polar", "scatter", "scatter_polar"):
+                kwargs["render_mode"] = render_mode
+
         # delayed evaluation of string to use kwargs
         title_format = self.pgdf.settings.title_format.value
         if title_format:

--- a/pandasgui/widgets/grapher.py
+++ b/pandasgui/widgets/grapher.py
@@ -1,4 +1,3 @@
-import datetime
 import inspect
 import sys
 from typing import NewType, Union, List, Callable, Iterable
@@ -15,8 +14,7 @@ import pandas as pd
 from pandasgui.store import PandasGuiStore, PandasGuiDataFrameStore, HistoryItem
 
 from pandasgui.widgets.plotly_viewer import PlotlyViewer, plotly_markers
-from pandasgui.utility import flatten_df, flatten_iter, kwargs_string, nunique, unique
-from pandasgui.widgets.plotly_viewer import PlotlyViewer
+from pandasgui.utility import flatten_df, flatten_iter, kwargs_string, nunique, unique, eval_title
 from pandasgui.widgets.dragger import Dragger, ColumnArg, Schema
 
 import logging
@@ -121,6 +119,20 @@ class Grapher(QtWidgets.QWidget):
             else:
                 kwargs[key] = val
 
+        # delayed evaluation of string to use kwargs
+        title_format = self.pgdf.settings.title_format.value
+        if title_format:
+            # user might have provided a title
+            title = kwargs.get("title", "")
+            if "{title}" in title:
+                # user is just adding to the default title
+                kwargs["title"] = title.replace("{title}", title_format)
+                kwargs["title"] = eval_title(self.pgdf, self.current_schema, kwargs)
+            elif title == "":
+                # nothing provided
+                kwargs["title"] = title_format
+                kwargs["title"] = eval_title(self.pgdf, self.current_schema, kwargs)
+
         func = self.current_schema.function
 
         self.fig = func(self.pgdf, kwargs)
@@ -167,13 +179,11 @@ def line(pgdf, kwargs):
             raise TypeError
 
     key_cols = list(set(key_cols))
-    print(kwargs, key_cols)
 
     if key_cols == []:
         df = pgdf.df
     else:
         df = pgdf.df.groupby(key_cols).mean().reset_index()
-
 
     if 'marker_symbol' in kwargs.keys():
 
@@ -282,7 +292,8 @@ def word_cloud(pgdf, kwargs):
     from wordcloud import WordCloud
     text = ' '.join(pd.concat([pgdf.df[x].dropna().astype(str) for x in columns]))
     wc = WordCloud(scale=2, collocations=False).generate(text)
-    fig = px.imshow(wc)
+    title = kwargs.get("title", "")
+    fig = px.imshow(wc, title=title)
 
     pgdf.history_imports.add("from wordcloud import WordCloud")
     pgdf.add_history_item("Grapher",
@@ -297,6 +308,7 @@ def word_cloud(pgdf, kwargs):
 
 schemas = [Schema(name='histogram',
                   args=[ColumnArg(arg_name='x'),
+                        ColumnArg(arg_name='y'),
                         ColumnArg(arg_name='color'),
                         ColumnArg(arg_name='facet_row'),
                         ColumnArg(arg_name='facet_col')],
@@ -332,6 +344,7 @@ schemas = [Schema(name='histogram',
                   args=[ColumnArg(arg_name='x'),
                         ColumnArg(arg_name='y'),
                         ColumnArg(arg_name='color'),
+                        ColumnArg(arg_name='hover_name'),
                         ColumnArg(arg_name='facet_row'),
                         ColumnArg(arg_name='facet_col')],
                   label='Bar',
@@ -386,13 +399,16 @@ schemas = [Schema(name='histogram',
                   icon_path=os.path.join(pandasgui.__path__[0], 'resources/images/draggers/trace-type-contour.svg')),
            Schema(name='pie',
                   args=[ColumnArg(arg_name='names'),
-                        ColumnArg(arg_name='values')],
+                        ColumnArg(arg_name='values'),
+                        ColumnArg(arg_name='color'),],
                   label='Pie',
                   function=pie,
                   icon_path=os.path.join(pandasgui.__path__[0], 'resources/images/draggers/trace-type-pie.svg')),
            Schema(name='scatter_matrix',
                   args=[ColumnArg(arg_name='dimensions'),
-                        ColumnArg(arg_name='color')],
+                        ColumnArg(arg_name='color'),
+                        ColumnArg(arg_name='symbol'),
+                        ColumnArg(arg_name='size'),],
                   label='Splom',
                   function=scatter_matrix,
                   icon_path=os.path.join(pandasgui.__path__[0], 'resources/images/draggers/trace-type-splom.svg')),


### PR DESCRIPTION
# Overview
- Added settings for `render_mode` and `title_format`. These can be passed to show() through settings.
- the settings have default values (defined in `constants.py`)
- they were added to `SettingsStore`
- Added derived identifiers for building title
- Added utility to create list of active filter expressions
- Added utility to remove units in parenthesis (for title - **axis labels not affected**)
- Adds generated `title` to kwargs, works on all charts
- In the process of testing, found and fixed:
  - wordcloud didn't pass `title` to imshow
  - histogram was missing `y` (comes into play with `orientation` / `histfunc` etc)
  - pie and scatter_matrix missing `color`
  - scatter_matrix missing `symbol` and `size`
- even with default title, it can be overwritten with `custom kwargs`
- it is also possible to add to default title by using `{title}` in the title custom kwarg (ie. `Chart 6: {title} `

Note, default title format is:
```
"{name}: {title_columns}{title_dimensions}{names}{title_y}{title_z}{over_by}{title_x} {selection}<br>"\
"<sub>{groupings}{filters} {title_trendline}</sub>"
```
Definition of the fields (also in utility.py comment):
```
Besides all dragger selections (x, y, z, color etc), and all custom kwargs, extra template variables are:

          date: current datetime
          filters: active filter expressions, comma delimited
          title_x: x minus units and with log scale if selected
          title_y: y minus units and with log scale if selected
          title_z: z minus units and with log scale if selected
          title_dimensions: dimensions list minus units
          title_columns: columns list minus units
          title_trendline: trendline description
          vs: when doing a title with x vs y, use {x}{vs}{y}
          over_by: when doing a title y over x, use {y}{ober_by}{x}. Preferred. for distributions, will use "by"
          name: dataframe name
          total: total number of observations
          subset: observations with active filters applied
          selection: ready to use string representing {subset} observations of {total}
          groupings: groupings tied to Legend and not on legend: marker_symbol, line_group, size etc
```
The title can also contain a few select html tags, like `<i></i>, <b></b>, <sub></sub>, <br>` etc (_whatever plotly supports_)

# Testing

## render_mode

Passed render_mode = 'auto', 'svg', 'webgl' and not passing it at all, worked as intended. svg was a few times slower than webgl/auto on a large set as expected, but at least that allows use of pandasgui without webgl.

## Title

### Histogram

filter applied:
![histogram_default_X](https://user-images.githubusercontent.com/1105325/108903950-e6825e80-75eb-11eb-95ae-8d24949032fb.png)

testing orientation:
![histogram_h_x_y_inverted](https://user-images.githubusercontent.com/1105325/108903955-e7b38b80-75eb-11eb-9035-3175bff8326a.png)

### Scatter

size not in legend, but in subtitle:
![scatter](https://user-images.githubusercontent.com/1105325/108904217-3c570680-75ec-11eb-8339-036734ea4245.png)

Lowess trendlines (requires statsmodels to be installed and the use of the `trendline` custom kwargs set to `lowess`:
![scatter_lowess](https://user-images.githubusercontent.com/1105325/108904235-3f51f700-75ec-11eb-95ed-fbe614d355ef.png)

OLS trendlines (requires statsmodels to be installed and the use of the `trendline` custom kwargs set to `ols`:
![scatter_trendlines](https://user-images.githubusercontent.com/1105325/108904238-40832400-75ec-11eb-8fe6-05b11e21e820.png)

### Line

This will have to be revisited once line and bar have groupby as optional, title is not totally accurate as it is not reflecting masked observations and the average.

Using log scale on Y:
![line_log_y](https://user-images.githubusercontent.com/1105325/108904813-f9e1f980-75ec-11eb-806e-931bc10e4e4a.png)

Regular scale:
![lines_gapminder](https://user-images.githubusercontent.com/1105325/108904820-fcdcea00-75ec-11eb-8c73-be4e53cc1fcf.png)

### Bar

See comment above on groupby for lines (for bar, in one case, average, in the other would be a count)

This is the current result with groupby:
![bar_with_groupby](https://user-images.githubusercontent.com/1105325/108905169-60ffae00-75ed-11eb-9f13-1a4272092fef.png)

With groupby disabled it would have looked something like this:
![bar_group_disabled](https://user-images.githubusercontent.com/1105325/108905166-60671780-75ed-11eb-8196-3d5b5e67739f.png)

### Box

Works fine with dark theme:
![box_titanic_extra_text](https://user-images.githubusercontent.com/1105325/108905492-c489db80-75ed-11eb-81b2-c63897d11d2f.png)

Title above has additional text, entered through custom kawrgs:
![extra_text](https://user-images.githubusercontent.com/1105325/109014870-8ab6e480-7682-11eb-9cbd-c16ca30b10c7.png)


While on the subject of dark theme, trying a different plot type:
![penguins_scatter](https://user-images.githubusercontent.com/1105325/108905496-c6539f00-75ed-11eb-9a81-28f024bfde37.png)

### Violin

[edited] Violin has similar title to box plot

![violin_correction](https://user-images.githubusercontent.com/1105325/108914239-108e4d80-75f9-11eb-89f0-1eb0841617af.png)

### Scatter 3D

most basic 3d plot:
![scatter_3d_just_title_when_no_filter_or_legend](https://user-images.githubusercontent.com/1105325/108905689-031f9600-75ee-11eb-8f4e-2cd1ce04f51e.png)

3d with log scale on Y, filter applied and using size:
![scatter_3d_mpg_with_log_scale_cubed_weight](https://user-images.githubusercontent.com/1105325/108905699-061a8680-75ee-11eb-8a9d-9ece23de435f.png)

### Heatmap

Heatmap with X/Y:
![heatmap_xy](https://user-images.githubusercontent.com/1105325/108905865-395d1580-75ee-11eb-941f-989916e8fc9e.png)

Heatmap with X/Y/Z default aggregation (note, this is sum for heatmap):
![heatmap_xyz_default](https://user-images.githubusercontent.com/1105325/108905871-3b26d900-75ee-11eb-8b14-909d9df3c36c.png)

Heatmap with X/Y/Z specified histfunc of `max`:
![heatmap_xyz_histfunc_max](https://user-images.githubusercontent.com/1105325/108905878-3cf09c80-75ee-11eb-96b0-57d5de681c21.png)

### Contour

Contour with X/Y:
![contour_xy](https://user-images.githubusercontent.com/1105325/108906172-95c03500-75ee-11eb-9889-69210e720a26.png)

Contour with X/Y/Z default aggregation (note, this is count for contour):
![contour_xyz_default](https://user-images.githubusercontent.com/1105325/108906224-a375ba80-75ee-11eb-8e50-847124e9530d.png)

Heatmap with X/Y/Z specified histfunc of `max`:
![contour_xyz_histfunc_max](https://user-images.githubusercontent.com/1105325/108906267-b1c3d680-75ee-11eb-9b22-98cbbba62738.png)

### Pie

Standard pie chart:
![pie](https://user-images.githubusercontent.com/1105325/108906414-dd46c100-75ee-11eb-9b74-791e9a7bed11.png)

Pie chart with custom kwarg:
![pie_donut](https://user-images.githubusercontent.com/1105325/108906418-de77ee00-75ee-11eb-8455-d0a71eb200d7.png)

### Scatter matrix

Multiple dimensions (with units removed in title), no filters, origin / model year in legend (color, symbol), size in subtitle, all possible elements in play:
![splom](https://user-images.githubusercontent.com/1105325/108906514-f9e2f900-75ee-11eb-89a4-ff5f7694d24b.png)


### Wordcloud

With filter applied:
![wordcloud](https://user-images.githubusercontent.com/1105325/108906597-10895000-75ef-11eb-9e51-1ff2589726b7.png)

# Closes

This closes #101

This closes #102 


END OF LINE