### PR TITLE
Bar and Line title and text

### DIFF
--- a/pandasgui/widgets/grapher.py
+++ b/pandasgui/widgets/grapher.py
@@ -191,7 +191,14 @@ def line(pgdf, kwargs):
     text = kwargs.get("text")
     marker_symbol = "marker_symbol" in kwargs.keys()
     mode = 'lines'
-    layout_kwargs = {}
+    trace_kwargs = {}
+    # optional
+    for trace_attribute in ['textfont', 'textfont_size', 'textfont_color', 'textfont_family', 'textposition',
+                             'texttemplate', 'showlegend']:
+        try:
+            trace_kwargs[trace_attribute] = kwargs.pop(trace_attribute)
+        except KeyError:
+            pass
     if marker_symbol or text:
         if marker_symbol:
             mode += "+markers"
@@ -200,13 +207,6 @@ def line(pgdf, kwargs):
             # don't add +text if we want to see text in hover instead of on the plot
             if texthover is None:
                 mode += "+text"
-            # optional
-            for layout_attribute in ['textfont', 'textfont_size', 'textfont_color', 'textfont_family', 'textposition', 'texttemplate',
-                                     'showlegend', 'legend_x', 'legend_xanchor', 'legend_y', 'legend_yanchor', 'legend_orientation']:
-                try:
-                    layout_kwargs[layout_attribute] = kwargs.pop(layout_attribute)
-                except KeyError:
-                    pass
 
         if marker_symbol:
             # get from custom kwargs, but invalid for px.line, so pop them
@@ -229,19 +229,21 @@ def line(pgdf, kwargs):
                         marker_symbol=plotly_markers[i % unique_markers],
                         marker_size=marker_size,
                         marker_line_width=marker_line_width,
-                        **layout_kwargs)
+                        **trace_kwargs)
                 else:
                     fig.add_traces(px.line(data_frame=df_sub, **kwargs).update_traces(
                         mode=mode,
                         marker_symbol=plotly_markers[i % unique_markers],
                         marker_size=marker_size,
                         marker_line_width=marker_line_width,
-                        **layout_kwargs).data)
+                        **trace_kwargs).data)
         else:
             # observations have text to label them, but no markers
-            fig = px.line(data_frame=df, **kwargs).update_traces(mode=mode, **layout_kwargs)
+            fig = px.line(data_frame=df, **kwargs).update_traces(mode=mode, **trace_kwargs)
     else:
         fig = px.line(data_frame=df, **kwargs)
+        if len(trace_kwargs) > 0:
+            fig = fig.update_traces(**trace_kwargs)
 
     if apply_sort and df[kwargs['x']].dtype.name == 'object':
         fig.update_xaxes(type='category', categoryorder='category ascending')
@@ -268,11 +270,20 @@ def bar(pgdf, kwargs):
             kwargs["title"] = title.replace("{groupby_obs}", str(df.shape[0]))
     if apply_sort and key_cols != []:
         df = df.sort_values(key_cols)
+    trace_kwargs = {}
+    for trace_attribute in ['textfont', 'textfont_size', 'textfont_color', 'textfont_family', 'textposition',
+                             'texttemplate', 'showlegend']:
+        try:
+            trace_kwargs[trace_attribute] = kwargs.pop(trace_attribute)
+        except KeyError:
+            pass
 
     pgdf.add_history_item("Grapher",
                           f"# *Code history for bar plot not yet fully implemented*\n"
                           f"fig = px.bar(data_frame=df, {kwargs_string(kwargs)})")
     fig = px.bar(data_frame=df, **kwargs)
+    if len(trace_kwargs) > 0:
+        fig = fig.update_traces(**trace_kwargs)
 
     if apply_sort and df[kwargs['x']].dtype.name == 'object':
         fig.update_xaxes(type='category', categoryorder='category ascending')

--- a/pandasgui/widgets/grapher.py
+++ b/pandasgui/widgets/grapher.py
@@ -182,37 +182,64 @@ def line(pgdf, kwargs):
     df = pgdf.df
     if apply_mean and key_cols != []:
         df = df.groupby(key_cols).mean().reset_index()
+        title = kwargs.get("title", "")
+        if "{groupby_obs}" in title:
+            # this wasn't available when we rendered the title
+            kwargs["title"] = title.replace("{groupby_obs}", str(df.shape[0]))
     if apply_sort and key_cols != []:
         df = df.sort_values(key_cols)
+    text = kwargs.get("text")
+    marker_symbol = "marker_symbol" in kwargs.keys()
+    mode = 'lines'
+    layout_kwargs = {}
+    if marker_symbol or text:
+        if marker_symbol:
+            mode += "+markers"
+        if text:
+            texthover = kwargs.pop('texthover', None)
+            # don't add +text if we want to see text in hover instead of on the plot
+            if texthover is None:
+                mode += "+text"
+            # optional
+            for layout_attribute in ['textfont', 'textfont_size', 'textfont_color', 'textfont_family', 'textposition', 'texttemplate',
+                                     'showlegend', 'legend_x', 'legend_xanchor', 'legend_y', 'legend_yanchor', 'legend_orientation']:
+                try:
+                    layout_kwargs[layout_attribute] = kwargs.pop(layout_attribute)
+                except KeyError:
+                    pass
 
-    if 'marker_symbol' in kwargs.keys():
-        # get from custom kwargs, but invalid for px.line, so pop them
-        marker_col = kwargs.pop('marker_symbol')
-        marker_size = kwargs.pop('marker_size', 10)  # optional
-        marker_line_width = kwargs.pop('marker_line_width', 2)  # optional
+        if marker_symbol:
+            # get from custom kwargs, but invalid for px.line, so pop them
+            marker_col = kwargs.pop('marker_symbol')
+            marker_size = kwargs.pop('marker_size', 10)  # optional
+            marker_line_width = kwargs.pop('marker_line_width', 2)  # optional
 
-        marker_unique = sorted(unique(df[marker_col]))
-        unique_markers = len(plotly_markers)
+            marker_unique = sorted(unique(df[marker_col]))
+            unique_markers = len(plotly_markers)
 
-        kwargs['hover_name'] = kwargs.get('hover_name', marker_col)
+            kwargs['hover_name'] = kwargs.get('hover_name', marker_col)
+            fig = None
 
-        fig = None
+            for i in range(0, len(marker_unique)):
+                df_sub = df[df[marker_col] == marker_unique[i]]
 
-        for i in range(0, len(marker_unique)):
-            df_sub = df[df[marker_col] == marker_unique[i]]
-
-            if fig is None:
-                fig = px.line(data_frame=df_sub, **kwargs).update_traces(
-                    mode='lines+markers',
-                    marker_symbol=plotly_markers[i % unique_markers],
-                    marker_size=marker_size,
-                    marker_line_width=marker_line_width)
-            else:
-                fig.add_traces(px.line(data_frame=df_sub, **kwargs).update_traces(
-                    mode='lines+markers',
-                    marker_symbol=plotly_markers[i % unique_markers],
-                    marker_size=marker_size,
-                    marker_line_width=marker_line_width).data)
+                if fig is None:
+                    fig = px.line(data_frame=df_sub, **kwargs).update_traces(
+                        mode=mode,
+                        marker_symbol=plotly_markers[i % unique_markers],
+                        marker_size=marker_size,
+                        marker_line_width=marker_line_width,
+                        **layout_kwargs)
+                else:
+                    fig.add_traces(px.line(data_frame=df_sub, **kwargs).update_traces(
+                        mode=mode,
+                        marker_symbol=plotly_markers[i % unique_markers],
+                        marker_size=marker_size,
+                        marker_line_width=marker_line_width,
+                        **layout_kwargs).data)
+        else:
+            # observations have text to label them, but no markers
+            fig = px.line(data_frame=df, **kwargs).update_traces(mode=mode, **layout_kwargs)
     else:
         fig = px.line(data_frame=df, **kwargs)
 
@@ -235,6 +262,10 @@ def bar(pgdf, kwargs):
     df = pgdf.df
     if apply_mean and key_cols != []:
         df = df.groupby(key_cols).mean().reset_index()
+        title = kwargs.get("title", "")
+        if "{groupby_obs}" in title:
+            # this wasn't available when we rendered the title
+            kwargs["title"] = title.replace("{groupby_obs}", str(df.shape[0]))
     if apply_sort and key_cols != []:
         df = df.sort_values(key_cols)
 
@@ -340,6 +371,7 @@ schemas = [Schema(name='histogram',
                         ColumnArg(arg_name='color'),
                         ColumnArg(arg_name='symbol'),
                         ColumnArg(arg_name='size'),
+                        ColumnArg(arg_name='text'),
                         ColumnArg(arg_name='hover_name'),
                         ColumnArg(arg_name='facet_row'),
                         ColumnArg(arg_name='facet_col')],
@@ -353,6 +385,7 @@ schemas = [Schema(name='histogram',
                         ColumnArg(arg_name='line_dash'),
                         ColumnArg(arg_name='line_group'),
                         ColumnArg(arg_name='marker_symbol'),
+                        ColumnArg(arg_name='text'),
                         ColumnArg(arg_name='hover_name'),
                         ColumnArg(arg_name='facet_row'),
                         ColumnArg(arg_name='facet_col'),
@@ -365,6 +398,7 @@ schemas = [Schema(name='histogram',
                   args=[ColumnArg(arg_name='x'),
                         ColumnArg(arg_name='y'),
                         ColumnArg(arg_name='color'),
+                        ColumnArg(arg_name='text'),
                         ColumnArg(arg_name='hover_name'),
                         ColumnArg(arg_name='facet_row'),
                         ColumnArg(arg_name='facet_col'),


### PR DESCRIPTION
# Overview

This PR improves titles for `bar` and for `line` charts with `apply_mean` and `apply_sort` variations. It reflects the correct true observations count or derived observations (due to `mean`). It also shows the correct aggregation function (count, mean, sum) as is appropriate for the plot.

The other piece of this PR is to add text support to `line` charts, along with a few basic text attributes for `bar` and `lines`:

```
'textfont_size', 'textfont_color', 'textfont_family', 'textposition', 'texttemplate'
```
If the above is found to be easy enough to use, the same should be applied to scatter.

# Testing

## Bar titles

With X only (no Y) and apply_mean:
![bar_x_only_apply_mean](https://user-images.githubusercontent.com/1105325/109714205-1db6b980-7b70-11eb-8fac-78516eb431a0.png)

With X only:
![bar_x_only](https://user-images.githubusercontent.com/1105325/109714206-1ee7e680-7b70-11eb-94a5-6c9ccd75b1ff.png)

with x and y, no mean or sort:
![bar_title_no_mean_no_sort](https://user-images.githubusercontent.com/1105325/109714209-20191380-7b70-11eb-9bb8-65d7ec033810.png)

with x and y with sort:
![bar_title_apply_sort](https://user-images.githubusercontent.com/1105325/109714214-21e2d700-7b70-11eb-8ba2-7bc2a1301001.png)

with x and y with mean and sort:
![bar_title_apply_mean_apply_sort](https://user-images.githubusercontent.com/1105325/109714217-23140400-7b70-11eb-8869-a472d568fe45.png)

## Line titles

with apply mean and sort:
![apply_mean_apply_sort](https://user-images.githubusercontent.com/1105325/109714807-da107f80-7b70-11eb-919a-df94f20ee570.jpg)

with sort only:
![apply_sort](https://user-images.githubusercontent.com/1105325/109714812-dbda4300-7b70-11eb-9024-31afa77db234.jpg)

with mean only:
![apply_mean](https://user-images.githubusercontent.com/1105325/109714820-de3c9d00-7b70-11eb-8f73-2a93bb0a1a5f.jpg)

and finally with no mean and no sort (_adding country for line dash to fully target all observations in the right order without group by or sort_)
![no_mean_no_sort](https://user-images.githubusercontent.com/1105325/109715045-1fcd4800-7b71-11eb-83ff-d77c8cfc142c.jpg)

## text

The previous gapminder data, `line` chart with `text = continent`:

![text_and_redundant_legend](https://user-images.githubusercontent.com/1105325/109715786-0d9fd980-7b72-11eb-959b-cd15413152ed.png)

In the above, legend is now redundant. `showlegend=False` and zooming in provides a great way to quickly see what's happening with GDP by continent in a specific timeframe (_also illustrating text attributes_):

![text_attributes_no_legend](https://user-images.githubusercontent.com/1105325/109716205-8b63e500-7b72-11eb-9feb-a8932b471a47.jpg)

The same can be applied on `bar` charts:

![text_attributes_bar](https://user-images.githubusercontent.com/1105325/109716318-b77f6600-7b72-11eb-86e8-0c54dafedcea.jpg)

# Closes

This closes #106 
This closes #109
