### PR TITLE
Set up grapher left and right sides as QSplitter

### DIFF
--- a/pandasgui/widgets/grapher.py
+++ b/pandasgui/widgets/grapher.py
@@ -65,16 +65,31 @@ class Grapher(QtWidgets.QWidget):
                                source_nunique=nunique(df).apply('{: >7}'.format).values,
                                source_types=df.dtypes.values.astype(str))
 
-        self.layout = QtWidgets.QGridLayout()
-        self.layout.addWidget(self.plot_type_picker, 0, 0)
-        self.layout.addWidget(self.dragger, 1, 0)
-        self.layout.addWidget(self.figure_viewer, 0, 1, 2, 1)
-        self.layout.setColumnStretch(0, 0)
-        self.layout.setColumnStretch(1, 1)
-        self.dragger.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
-        self.plot_type_picker.setSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Preferred)
+        self.plot_splitter = QtWidgets.QSplitter(Qt.Horizontal)
+        self.plot_splitter.setHandleWidth(3)
+        self.left_panel = QtWidgets.QGridLayout()
+        self.left_panel.addWidget(self.plot_type_picker, 0, 0)
+        self.left_panel.addWidget(self.dragger, 1, 0)
 
+        self.dragger.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
+
+        self.plot_type_picker.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
+
+        # QGrid for first half of splitter
+        self.selection_grid = QtWidgets.QWidget()
+        self.selection_grid.setLayout(self.left_panel)
+        self.plot_splitter.addWidget(self.selection_grid)
+
+        # Figure Viewer for the second half of splitter
+        self.figure_viewer.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
+        self.plot_splitter.addWidget(self.figure_viewer)
+
+        self.plot_splitter.setStretchFactor(1, 1)
+
+        self.layout = QtWidgets.QGridLayout()
+        self.layout.addWidget(self.plot_splitter)
         self.setLayout(self.layout)
+
 
         # Signals
         self.plot_type_picker.itemSelectionChanged.connect(self.on_type_changed)

--- a/pandasgui/widgets/grapher.py
+++ b/pandasgui/widgets/grapher.py
@@ -90,7 +90,6 @@ class Grapher(QtWidgets.QWidget):
         self.layout.addWidget(self.plot_splitter)
         self.setLayout(self.layout)
 
-
         # Signals
         self.plot_type_picker.itemSelectionChanged.connect(self.on_type_changed)
         self.dragger.finished.connect(self.on_dragger_finished)


### PR DESCRIPTION
# Overview

This PR addresses issue #111. It doesn't fully resolve #112, as the dragger splitter is not movable, but the dragger widget does expand/contract if the splitter between the left and right side of the grapher is moved right / left.

# Test

Default layout when launching:
![default](https://user-images.githubusercontent.com/1105325/111501013-fab50980-871a-11eb-9b79-3c6bca6fae53.png)

Full screen default split:
![full_screen](https://user-images.githubusercontent.com/1105325/111501076-09032580-871b-11eb-97d0-9000841a54c2.png)

Dragging splitter left:
![drag_splitter_left](https://user-images.githubusercontent.com/1105325/111501128-15877e00-871b-11eb-9d46-4e6d59596819.png)

Dragging splitter all the way left:
![drag_all_the_way_left](https://user-images.githubusercontent.com/1105325/111501210-2801b780-871b-11eb-943b-e2d7db4da14f.png)

Grapher tab popped out:
![tab_popped_out](https://user-images.githubusercontent.com/1105325/111501258-351ea680-871b-11eb-9a0b-edffcc8f2738.png)

# Fix

This issue closes #111