### PR TITLE
More configs

### DIFF
--- a/pandasgui/store.py
+++ b/pandasgui/store.py
@@ -91,6 +91,7 @@ class Setting(DictLike):
 DEFAULT_SETTINGS = {'editable': True,
                     'block': None,
                     'theme': 'light',
+                    'auto_finish': True,
                     'refresh_statistics': False,
                     'render_mode': 'auto',
                     'aggregation': 'mean',
@@ -107,6 +108,7 @@ class SettingsStore(DictLike, QtCore.QObject):
     block: Setting
     editable: Setting
     theme: Setting
+    auto_finish: Setting
     render_mode: Setting
     aggregation: Setting
     title_format: Setting
@@ -156,6 +158,12 @@ class SettingsStore(DictLike, QtCore.QObject):
                                           persist=True)
 
         # Settings related to Grapher
+
+        self.auto_finish = Setting(label="auto_finish",
+                                   value=settings['auto_finish'],
+                                   description="Automatically renders plot after each drag and drop",
+                                   dtype=bool,
+                                   persist=True)
 
         self.render_mode = Setting(label="render_mode",
                                    value=settings['render_mode'],

--- a/pandasgui/widgets/grapher.py
+++ b/pandasgui/widgets/grapher.py
@@ -134,7 +134,8 @@ class Grapher(QtWidgets.QWidget):
         # Signals
         self.type_picker.itemSelectionChanged.connect(self.on_type_changed)
         self.func_ui.finished.connect(self.on_dragger_finished)
-        self.func_ui.valuesChanged.connect(self.on_dragger_finished)
+        if pgdf.store.settings.auto_finish.value:
+            self.func_ui.valuesChanged.connect(self.on_dragger_finished)
         self.func_ui.saving.connect(self.on_dragger_saving)
 
     def on_type_changed(self):
@@ -251,7 +252,8 @@ if __name__ == "__main__":
 
     app = QtWidgets.QApplication.instance() or QtWidgets.QApplication(sys.argv)
 
-    gb = Grapher(pokemon)
+    pgdf = PandasGuiDataFrameStore(pokemon)
+    gb = Grapher(pgdf)
     gb.show()
 
     gb.set_state('scatter', {'y': 'Attack', 'x': 'Defense'})


### PR DESCRIPTION
From the redesign issue:

- Add checkbox to disable automatic re-rendering

This is added to the settings and can be enabled / disabled.

I also fixed the standalone launch of the grapher as Grapher expects a PGDF, not a regular dataframe.