### PR TITLE
Add pywin32 requirement for Windows installations

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pyarrow
 astor
 typing-extensions
 qtstylish>=0.1.2
+pywin32; platform_system=="Windows"

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,6 @@ setup(
         "astor",
         "typing-extensions",
         "qtstylish>=0.1.2",
+        "pywin32; platform_system=='Windows'"
     ],
 )


### PR DESCRIPTION
This should make sure pywin32 is installed on Windows systems since it provides win32api which is required when doing `from pandasgui import show`, 

This should fix issue #172 .