### PR TITLE
Switch to qtpy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,7 +19,7 @@ IDE: (eg. PyCharm)
 
 **Package versions**  
 TO GET ALL RELEVANT PACKAGE VERSIONS, RUN THIS COMMAND IN BASH AND PASTE THE OUTPUT
-pip freeze | grep -i "pyqt\|pandasgui\|plotly\|ipython\|jupyter\|notebook"
+pip freeze | grep -i "pyqt\|pyside\|pandasgui\|plotly\|ipython\|jupyter\|notebook"
 
 EXAMPLE OUTPUT
 ```

--- a/demo.py
+++ b/demo.py
@@ -12,7 +12,7 @@ show(pokemon_stats=pokemon, mi_example=multiindex)
 show(**all_datasets)
 
 # The only reserved argument name is `settings`, which accepts a dictionary of settings for the GUI.
-show(pokemon, settings={'theme':'dark', ''})
+show(pokemon, settings={'theme':'dark'})
 # PandasGUI will attempt to convert any object you pass to `show` into a DataFrame
 show(test1={'a': [1, 2, 3]}, test2=[5, 6, 7, 8, 9])
 
@@ -21,4 +21,4 @@ gui = show(pokemon, mpg)
 pokemon_new = gui['pokemon']
 
 # Use the `pg` IPython magic command to directly modify DataFrames in the GUI
-%pg pokemon['Null Type'] = pokemon['Type 1'].isna()
+# %pg pokemon['Null Type'] = pokemon['Type 1'].isna()

--- a/pandasgui/gui.py
+++ b/pandasgui/gui.py
@@ -6,8 +6,8 @@ from typing import Callable, Union
 from dataclasses import dataclass
 import pandas as pd
 import pkg_resources
-from PyQt5 import QtCore, QtGui, QtWidgets
-from PyQt5.QtCore import Qt
+from qtpy import QtCore, QtGui, QtWidgets
+from qtpy.QtCore import Qt
 
 import pandasgui
 from pandasgui.store import PandasGuiStore

--- a/pandasgui/store.py
+++ b/pandasgui/store.py
@@ -14,7 +14,7 @@ from typing import Iterable, List, Union
 from typing_extensions import Literal
 import pandas as pd
 from pandas import DataFrame
-from PyQt5 import QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets
 import traceback
 from datetime import datetime
 from pandasgui.utility import unique_name, in_interactive_console, refactor_variable, clean_dataframe, nunique, \
@@ -98,7 +98,7 @@ DEFAULT_SETTINGS = {'editable': True,
 
 @dataclass
 class SettingsStore(DictLike, QtCore.QObject):
-    settingsChanged = QtCore.pyqtSignal()
+    settingsChanged = QtCore.Signal()
 
     block: Setting
     editable: Setting

--- a/pandasgui/utility.py
+++ b/pandasgui/utility.py
@@ -1,6 +1,6 @@
 import logging
 import pandas as pd
-from PyQt5 import QtWidgets
+from qtpy import QtWidgets
 from typing import List, Union
 import sys
 import inspect
@@ -319,7 +319,7 @@ def test_logging():
 
 # Resize a widget to a percentage of the screen size
 def resize_widget(widget, x, y):
-    from PyQt5 import QtCore, QtWidgets
+    from qtpy import QtCore, QtWidgets
     widget.resize(QtCore.QSize(int(x * QtWidgets.QDesktopWidget().screenGeometry().width()),
                                int(y * QtWidgets.QDesktopWidget().screenGeometry().height())))
 

--- a/pandasgui/widgets/base_widgets.py
+++ b/pandasgui/widgets/base_widgets.py
@@ -1,9 +1,9 @@
-from PyQt5 import QtGui, QtWidgets
-from PyQt5.QtCore import pyqtSignal
+from qtpy import QtGui, QtWidgets
+from qtpy.QtCore import Signal
 
 
 class QTreeWidget(QtWidgets.QTreeWidget):
-    onDropSignal = pyqtSignal()
+    onDropSignal = Signal()
 
     # Autosize columns
     def showEvent(self, event: QtGui.QShowEvent):

--- a/pandasgui/widgets/code_history_viewer.py
+++ b/pandasgui/widgets/code_history_viewer.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-from PyQt5 import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 from pandasgui.store import PandasGuiDataFrameStore, SETTINGS_STORE
 import pandasgui

--- a/pandasgui/widgets/collapsible_panel.py
+++ b/pandasgui/widgets/collapsible_panel.py
@@ -1,4 +1,4 @@
-from PyQt5 import QtWidgets
+from qtpy import QtWidgets
 
 
 class CollapsiblePanel(QtWidgets.QGroupBox):

--- a/pandasgui/widgets/column_menu.py
+++ b/pandasgui/widgets/column_menu.py
@@ -4,7 +4,7 @@ Menu that appears on right clicking a column header. Contains options for modify
 
 import sys
 
-from PyQt5 import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 from pandasgui.store import PandasGuiDataFrameStore
 

--- a/pandasgui/widgets/column_viewer.py
+++ b/pandasgui/widgets/column_viewer.py
@@ -1,8 +1,8 @@
 import sys
 
-from PyQt5 import QtWidgets, QtGui, QtCore
-from PyQt5.QtCore import Qt, pyqtSignal
-from PyQt5.QtGui import QMouseEvent
+from qtpy import QtWidgets, QtGui, QtCore
+from qtpy.QtCore import Qt, Signal
+from qtpy.QtGui import QMouseEvent
 
 from pandasgui.store import PandasGuiDataFrameStore
 from pandasgui.utility import nunique
@@ -10,7 +10,7 @@ from pandasgui.widgets import base_widgets
 
 
 class FlatDraggableTree(base_widgets.QTreeWidget):
-    mouseReleaseEventSignal = pyqtSignal(QMouseEvent)
+    mouseReleaseEventSignal = Signal(QMouseEvent)
 
     def __init__(self):
         super().__init__()

--- a/pandasgui/widgets/containers.py
+++ b/pandasgui/widgets/containers.py
@@ -1,4 +1,4 @@
-from PyQt5 import QtWidgets
+from qtpy import QtWidgets
 
 
 class Container(QtWidgets.QGroupBox):

--- a/pandasgui/widgets/dataframe_explorer.py
+++ b/pandasgui/widgets/dataframe_explorer.py
@@ -1,7 +1,7 @@
 import sys
 from typing import List
-from PyQt5 import QtWidgets, QtGui, QtCore
-from PyQt5.QtCore import Qt
+from qtpy import QtWidgets, QtGui, QtCore
+from qtpy.QtCore import Qt
 from pandasgui.widgets.code_history_viewer import CodeHistoryViewer
 
 from pandasgui.widgets.containers import Container

--- a/pandasgui/widgets/dataframe_viewer.py
+++ b/pandasgui/widgets/dataframe_viewer.py
@@ -5,8 +5,8 @@ from typing import Union
 
 import numpy as np
 import pandas as pd
-from PyQt5 import QtCore, QtGui, QtWidgets
-from PyQt5.QtCore import Qt
+from qtpy import QtCore, QtGui, QtWidgets
+from qtpy.QtCore import Qt
 from typing_extensions import Literal
 from pandasgui.store import PandasGuiDataFrameStore
 import pandasgui

--- a/pandasgui/widgets/detachable_tab_widget.py
+++ b/pandasgui/widgets/detachable_tab_widget.py
@@ -1,7 +1,7 @@
 # https://stackoverflow.com/q/47267195/3620725
 
-from PyQt5 import QtGui, QtCore, QtWidgets
-from PyQt5.QtCore import pyqtSignal, pyqtSlot
+from qtpy import QtGui, QtCore, QtWidgets
+from qtpy.QtCore import Signal, Slot
 
 
 class DetachableTabWidget(QtWidgets.QTabWidget):
@@ -33,7 +33,7 @@ class DetachableTabWidget(QtWidgets.QTabWidget):
     #
     #  @param    fromIndex    the original index location of the tab
     #  @param    toIndex      the new index location of the tab
-    @pyqtSlot(int, int)
+    @Slot(int, int)
     def moveTab(self, fromIndex, toIndex):
         widget = self.widget(fromIndex)
         icon = self.tabIcon(fromIndex)
@@ -49,7 +49,7 @@ class DetachableTabWidget(QtWidgets.QTabWidget):
     #
     #  @param    index    the index location of the tab to be detached
     #  @param    point    the screen position for creating the new DetachedTab window
-    @pyqtSlot(int, QtCore.QPoint)
+    @Slot(int, QtCore.QPoint)
     def detachTab(self, index, point):
 
         # Get the tab content
@@ -162,7 +162,7 @@ class DetachableTabWidget(QtWidgets.QTabWidget):
     #                     determined that the drop occurred on an
     #                     existing tab)
     #  @param    dropPos  the mouse cursor position when the drop occurred
-    @QtCore.pyqtSlot(str, int, QtCore.QPoint)
+    @QtCore.Slot(str, int, QtCore.QPoint)
     def detachedTabDrop(self, name, index, dropPos):
 
         # If the drop occurred on an existing tab, insert the detached
@@ -217,8 +217,8 @@ class DetachableTabWidget(QtWidgets.QTabWidget):
     #  When a tab is detached, the contents are placed into this QMainWindow.  The tab
     #  can be re-attached by closing the dialog or by dragging the window into the tab bar
     class DetachedTab(QtWidgets.QMainWindow):
-        onCloseSignal = pyqtSignal(QtWidgets.QWidget, str, QtGui.QIcon)
-        onDropSignal = pyqtSignal(str, QtCore.QPoint)
+        onCloseSignal = Signal(QtWidgets.QWidget, str, QtGui.QIcon)
+        onDropSignal = Signal(str, QtCore.QPoint)
 
         def __init__(self, name, contentWidget):
             QtWidgets.QMainWindow.__init__(self, None)
@@ -238,7 +238,7 @@ class DetachableTabWidget(QtWidgets.QTabWidget):
         #  Handle a window drop event
         #
         #  @param    dropPos    the mouse cursor position of the drop
-        @QtCore.pyqtSlot(QtCore.QPoint)
+        @QtCore.Slot(QtCore.QPoint)
         def windowDropSlot(self, dropPos):
             self.onDropSignal.emit(self.objectName(), dropPos)
 
@@ -253,7 +253,7 @@ class DetachableTabWidget(QtWidgets.QTabWidget):
         ##
         #  An event filter class to detect a QMainWindow drop event
         class WindowDropFilter(QtCore.QObject):
-            onDropSignal = pyqtSignal(QtCore.QPoint)
+            onDropSignal = Signal(QtCore.QPoint)
 
             def __init__(self):
                 QtCore.QObject.__init__(self)
@@ -285,9 +285,9 @@ class DetachableTabWidget(QtWidgets.QTabWidget):
     ##
     #  The TabBar class re-implements some of the functionality of the QTabBar widget
     class TabBar(QtWidgets.QTabBar):
-        onDetachTabSignal = pyqtSignal(int, QtCore.QPoint)
-        onMoveTabSignal = pyqtSignal(int, int)
-        detachedTabDropSignal = pyqtSignal(str, int, QtCore.QPoint)
+        onDetachTabSignal = Signal(int, QtCore.QPoint)
+        onMoveTabSignal = Signal(int, int)
+        detachedTabDropSignal = Signal(str, int, QtCore.QPoint)
 
         def __init__(self, parent=None):
             QtWidgets.QTabBar.__init__(self, parent)

--- a/pandasgui/widgets/dialogs.py
+++ b/pandasgui/widgets/dialogs.py
@@ -1,6 +1,6 @@
 import sys
 
-from PyQt5 import QtWidgets
+from qtpy import QtWidgets
 
 
 

--- a/pandasgui/widgets/dock_widget.py
+++ b/pandasgui/widgets/dock_widget.py
@@ -1,10 +1,10 @@
-from PyQt5 import QtCore, QtGui, QtWidgets
-from PyQt5.QtCore import Qt
+from qtpy import QtCore, QtGui, QtWidgets
+from qtpy.QtCore import Qt
 
 
 class DockWidget(QtWidgets.QDockWidget):
     # This signal is used to track which dock is considered active or focussed
-    activated = QtCore.pyqtSignal()
+    activated = QtCore.Signal()
 
     def __init__(self, title: str, pgdf_name: str = 'Untitled'):
         super().__init__(title)

--- a/pandasgui/widgets/figure_viewer.py
+++ b/pandasgui/widgets/figure_viewer.py
@@ -2,9 +2,9 @@ import os
 import sys
 import tempfile
 
-from PyQt5 import QtCore, QtGui, QtWidgets, sip
-from PyQt5.QtCore import Qt
-import PyQt5
+from qtpy import QtCore, QtGui, QtWidgets, sip
+from qtpy.QtCore import Qt
+import qtpy
 import logging
 
 from pandasgui.store import PandasGuiStoreItem
@@ -19,23 +19,23 @@ os.environ["QTWEBENGINE_CHROMIUM_FLAGS"] = "--enable-logging --log-level=3"
 # we need to hack around this import restriction on QtWebEngineWidgets
 # https://stackoverflow.com/a/57436077/3620725
 
-if "PyQt5.QtWebEngineWidgets" not in sys.modules:
+if "qtpy.QtWebEngineWidgets" not in sys.modules:
     app = QtWidgets.QApplication.instance()
 
     if app is None:
-        from PyQt5 import QtWebEngineWidgets
+        from qtpy import QtWebEngineWidgets
     else:
         logger.warning("Reinitializing existing QApplication to allow import of QtWebEngineWidgets. "
                        "This may cause problems. "
-                       "To avoid this, import pandasgui or PyQt5.QtWebEngineWidgets before a QApplication is created.")
+                       "To avoid this, import pandasgui or QtWebEngineWidgets before a QApplication is created.")
         app.quit()
         sip.delete(app)
-        from PyQt5 import QtWebEngineWidgets
+        from qtpy import QtWebEngineWidgets
 
         app.__init__(sys.argv + ["--ignore-gpu-blacklist", "--enable-gpu-rasterization"])
 
 
-class FigureViewer(PyQt5.QtWebEngineWidgets.QWebEngineView, PandasGuiStoreItem):
+class FigureViewer(qtpy.QtWebEngineWidgets.QWebEngineView, PandasGuiStoreItem):
     def __init__(self, fig=None, store=None):
         super().__init__()
         self.store = store
@@ -43,7 +43,7 @@ class FigureViewer(PyQt5.QtWebEngineWidgets.QWebEngineView, PandasGuiStoreItem):
 
         # Fix scrollbar sometimes disappearing after Plotly autosizes and leaving behind white space
         self.settings().setAttribute(self.settings().ShowScrollBars, False)
-        self.settings().setAttribute(PyQt5.QtWebEngineWidgets.QWebEngineSettings.WebGLEnabled, True)
+        self.settings().setAttribute(qtpy.QtWebEngineWidgets.QWebEngineSettings.WebGLEnabled, True)
 
         # https://stackoverflow.com/a/8577226/3620725
         self.temp_file = tempfile.NamedTemporaryFile(mode="w", suffix=".html", delete=False)

--- a/pandasgui/widgets/filter_viewer.py
+++ b/pandasgui/widgets/filter_viewer.py
@@ -2,10 +2,10 @@ import os
 import re
 import sys
 
-from PyQt5 import QtCore, QtGui, QtWidgets
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QDesktopServices
-from PyQt5.QtCore import QUrl
+from qtpy import QtCore, QtGui, QtWidgets
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QDesktopServices
+from qtpy.QtCore import QUrl
 from pandasgui.utility import nunique, unique
 
 from pandasgui.store import PandasGuiDataFrameStore

--- a/pandasgui/widgets/find_toolbar.py
+++ b/pandasgui/widgets/find_toolbar.py
@@ -2,8 +2,8 @@ import re
 import time
 
 import pkg_resources
-from PyQt5 import QtCore, QtGui, QtWidgets
-from PyQt5.QtCore import Qt
+from qtpy import QtCore, QtGui, QtWidgets
+from qtpy.QtCore import Qt
 
 
 class FindToolbar(QtWidgets.QToolBar):
@@ -129,7 +129,7 @@ class FindToolbar(QtWidgets.QToolBar):
         # hide toolbar
         self.setFixedHeight(0)
 
-    @QtCore.pyqtSlot(str)
+    @QtCore.Slot(str)
     def query(self, text):
         """
         Query operation done each time user changes the text.
@@ -159,7 +159,7 @@ class FindToolbar(QtWidgets.QToolBar):
         self.findThread.matches.connect(self.update_matches)
         self.findThread.start()
 
-    @QtCore.pyqtSlot(list)
+    @QtCore.Slot(list)
     def update_matches(self, cells_matched):
         """
         PyQt Slot that updates the matches found each time it gets a signal.
@@ -184,7 +184,7 @@ class FindToolbar(QtWidgets.QToolBar):
             self.search_selection = 0
             self.highlight_match()
 
-    @QtCore.pyqtSlot()
+    @QtCore.Slot()
     def show_find_bar(self):
         if self.height() == 0:
             animation_duration = 200
@@ -203,7 +203,7 @@ class FindToolbar(QtWidgets.QToolBar):
             self.find_textbox.setText("")
             self.find_textbox.setFocus()
 
-    @QtCore.pyqtSlot()
+    @QtCore.Slot()
     def hide_find_bar(self):
         if self.height() == 30:
             animation_duration = 200
@@ -222,7 +222,7 @@ class FindToolbar(QtWidgets.QToolBar):
             if self.findThread:
                 self.findThread.stop()
 
-    @QtCore.pyqtSlot()
+    @QtCore.Slot()
     def select_next_match(self):
         if self.search_matches:
             # loop around to the first match if user hits last match
@@ -233,7 +233,7 @@ class FindToolbar(QtWidgets.QToolBar):
 
             self.highlight_match()
 
-    @QtCore.pyqtSlot()
+    @QtCore.Slot()
     def select_previous_match(self):
         if self.search_matches:
             # loop around to the last match if user hits first match
@@ -244,14 +244,14 @@ class FindToolbar(QtWidgets.QToolBar):
 
             self.highlight_match()
 
-    @QtCore.pyqtSlot()
+    @QtCore.Slot()
     def toggle_match_case(self):
         self.match_flags["case"] = not self.match_flags["case"]
 
         if self.find_textbox.text():
             self.query(self.find_textbox.text())
 
-    @QtCore.pyqtSlot()
+    @QtCore.Slot()
     def toggle_regex(self):
         self.match_flags["regex"] = not self.match_flags["regex"]
         if self.match_flags["whole word"]:
@@ -261,7 +261,7 @@ class FindToolbar(QtWidgets.QToolBar):
         if self.find_textbox.text():
             self.query(self.find_textbox.text())
 
-    @QtCore.pyqtSlot()
+    @QtCore.Slot()
     def toggle_match_exactly(self):
         self.match_flags["whole word"] = not self.match_flags["whole word"]
         if self.match_flags["regex"]:
@@ -283,7 +283,7 @@ class FindToolbar(QtWidgets.QToolBar):
 
 
 class ButtonLineEdit(QtWidgets.QLineEdit):
-    buttonClicked = QtCore.pyqtSignal(bool)
+    buttonClicked = QtCore.Signal(bool)
 
     def __init__(self, parent=None, content_margins=(0, 0, 0, 0)):
         """
@@ -336,7 +336,7 @@ class ButtonLineEdit(QtWidgets.QLineEdit):
 
 
 class FindThread(QtCore.QThread):
-    matches = QtCore.pyqtSignal(list)
+    matches = QtCore.Signal(list)
 
     def __init__(self, df, text, match_flags, parent=None):
         """

--- a/pandasgui/widgets/func_ui.py
+++ b/pandasgui/widgets/func_ui.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 
-from PyQt5 import QtCore, QtGui, QtWidgets, sip
-from PyQt5.QtCore import Qt
+from qtpy import QtCore, QtGui, QtWidgets, sip
+from qtpy.QtCore import Qt
 from typing import List, Callable
 import os
 import inspect
@@ -153,10 +153,10 @@ class SourceTree(ColumnViewer):
         self.tree.setHeaderLabels(['Name', '#Unique', 'Type'])
 
 class FuncUi(QtWidgets.QWidget):
-    valuesChanged = QtCore.pyqtSignal()
-    itemDropped = QtCore.pyqtSignal()
-    finished = QtCore.pyqtSignal()
-    saving = QtCore.pyqtSignal()
+    valuesChanged = QtCore.Signal()
+    itemDropped = QtCore.Signal()
+    finished = QtCore.Signal()
+    saving = QtCore.Signal()
 
     def __init__(self, pgdf, schema: Schema = None):
         super().__init__()
@@ -509,7 +509,7 @@ class FuncUi(QtWidgets.QWidget):
 
 
 class ColumnDropZone(QtWidgets.QLineEdit):
-    valueChanged = QtCore.pyqtSignal(str)
+    valueChanged = QtCore.Signal(str)
 
     def __init__(self):
         super().__init__()
@@ -564,7 +564,7 @@ class ColumnDropZone(QtWidgets.QLineEdit):
 
 
 class ColumnListDropZone(QtWidgets.QListWidget):
-    valueChanged = QtCore.pyqtSignal(list)  # List of strings
+    valueChanged = QtCore.Signal(list)  # List of strings
 
     def __init__(self):
         super().__init__()
@@ -738,7 +738,7 @@ class CustomKwargsEditor(QtWidgets.QDialog):
 
 if __name__ == "__main__":
     import sys
-    from PyQt5.QtWidgets import QApplication
+    from qtpy.QtWidgets import QApplication
     from pandasgui.datasets import pokemon
 
     app = QApplication(sys.argv)

--- a/pandasgui/widgets/grapher.py
+++ b/pandasgui/widgets/grapher.py
@@ -1,13 +1,13 @@
 import sys
 
-from PyQt5.QtWidgets import QStyleOptionViewItem
+from qtpy.QtWidgets import QStyleOptionViewItem
 
 import pandasgui
 import os
 import plotly
 
-from PyQt5 import QtCore, QtGui, QtWidgets
-from PyQt5.QtCore import Qt
+from qtpy import QtCore, QtGui, QtWidgets
+from qtpy.QtCore import Qt
 from pandasgui.jotly import generate_title
 
 from pandasgui.store import PandasGuiDataFrameStore

--- a/pandasgui/widgets/json_viewer.py
+++ b/pandasgui/widgets/json_viewer.py
@@ -1,6 +1,6 @@
 import sys
 from typing import Union, List
-from PyQt5 import QtCore, QtGui, QtWidgets
+from qtpy import QtCore, QtGui, QtWidgets
 
 from pandasgui.store import PandasGuiStoreItem
 from pandasgui.utility import summarize_json, traverse_tree_widget

--- a/pandasgui/widgets/navigator.py
+++ b/pandasgui/widgets/navigator.py
@@ -1,6 +1,6 @@
 
-from PyQt5 import QtCore, QtGui, QtWidgets, sip
-from PyQt5.QtCore import Qt
+from qtpy import QtCore, QtGui, QtWidgets, sip
+from qtpy.QtCore import Qt
 
 from pandasgui.store import PandasGuiDataFrameStore, PandasGuiStore
 from pandasgui.widgets import base_widgets

--- a/pandasgui/widgets/python_highlighter.py
+++ b/pandasgui/widgets/python_highlighter.py
@@ -1,9 +1,9 @@
 # https://github.com/art1415926535/PyQt5-syntax-highlighting
 
-from PyQt5 import QtWidgets
+from qtpy import QtWidgets
 
-from PyQt5.QtCore import QRegExp
-from PyQt5.QtGui import QColor, QTextCharFormat, QFont, QSyntaxHighlighter
+from qtpy.QtCore import QRegExp
+from qtpy.QtGui import QColor, QTextCharFormat, QFont, QSyntaxHighlighter
 
 def format(color, style=''):
     """

--- a/pandasgui/widgets/reshaper.py
+++ b/pandasgui/widgets/reshaper.py
@@ -1,12 +1,12 @@
 import sys
 
-from PyQt5.QtWidgets import QStyleOptionViewItem
+from qtpy.QtWidgets import QStyleOptionViewItem
 
 import pandasgui
 import os
 
-from PyQt5 import QtCore, QtGui, QtWidgets
-from PyQt5.QtCore import Qt
+from qtpy import QtCore, QtGui, QtWidgets
+from qtpy.QtCore import Qt
 
 from pandasgui.store import PandasGuiDataFrameStore
 from pandasgui.widgets.collapsible_panel import CollapsiblePanel

--- a/pandasgui/widgets/searchable_combobox.py
+++ b/pandasgui/widgets/searchable_combobox.py
@@ -2,8 +2,8 @@
 
 # https://stackoverflow.com/a/7693234/3620725
 
-from PyQt5 import QtCore, QtWidgets
-from PyQt5.QtCore import Qt
+from qtpy import QtCore, QtWidgets
+from qtpy.QtCore import Qt
 
 
 class SearchableComboBox(QtWidgets.QComboBox):
@@ -53,7 +53,7 @@ class SearchableComboBox(QtWidgets.QComboBox):
 
 if __name__ == "__main__":
     import sys
-    from PyQt5.QtWidgets import QApplication
+    from qtpy.QtWidgets import QApplication
 
     app = QApplication(sys.argv)
     string_list = ["hola muchachos", "adios amigos", "hello world", "good bye"]

--- a/pandasgui/widgets/searchable_list.py
+++ b/pandasgui/widgets/searchable_list.py
@@ -1,5 +1,5 @@
 import re
-from PyQt5 import QtWidgets
+from qtpy import QtWidgets
 
 
 class SearchableListWidget(QtWidgets.QWidget):
@@ -42,7 +42,7 @@ class SearchableListWidget(QtWidgets.QWidget):
 
 if __name__ == "__main__":
     import sys
-    from PyQt5.QtWidgets import QApplication
+    from qtpy.QtWidgets import QApplication
 
     app = QApplication(sys.argv)
 

--- a/pandasgui/widgets/settings_editor.py
+++ b/pandasgui/widgets/settings_editor.py
@@ -2,8 +2,8 @@ import ast
 import pprint
 
 import typing
-from PyQt5 import QtWidgets
-from PyQt5.QtCore import Qt
+from qtpy import QtWidgets
+from qtpy.QtCore import Qt
 import sys
 from pandasgui.store import SETTINGS_STORE, SettingsStore
 from pandasgui.widgets import base_widgets

--- a/pandasgui/widgets/spinner.py
+++ b/pandasgui/widgets/spinner.py
@@ -1,8 +1,8 @@
 from math import ceil
 
-from PyQt5.QtCore import *
-from PyQt5.QtGui import *
-from PyQt5.QtWidgets import *
+from qtpy.QtCore import *
+from qtpy.QtGui import *
+from qtpy.QtWidgets import *
 
 
 class Spinner(QWidget):
@@ -33,7 +33,7 @@ class Spinner(QWidget):
         self.updateTimer()
         self.hide()
 
-    @pyqtSlot()
+    @Slot()
     def rotate(self):
         self.mCurrentCounter += 1
         if self.mCurrentCounter > self.numberOfLines():

--- a/pandasgui/widgets/stats_viewer.py
+++ b/pandasgui/widgets/stats_viewer.py
@@ -1,5 +1,5 @@
 import sys
-from PyQt5 import QtWidgets
+from qtpy import QtWidgets
 
 from pandasgui.utility import clear_layout
 from pandasgui.widgets.dataframe_viewer import DataFrameViewer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 pandas
-PyQt5
-PyQt5-sip
-PyQtWebEngine
+qtpy
 plotly
 wordcloud
 setuptools

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,7 @@ setup(
     install_requires=[
         "pandas",
         "numpy",
-        "PyQt5",
-        "PyQt5-sip",
-        "PyQtWebEngine",
+        "qtpy",
         "plotly",
         "wordcloud",
         "setuptools",
@@ -34,7 +32,7 @@ setup(
         "astor",
         "typing-extensions",
         "qtstylish>=0.1.2",
-        "pywin32; platform_system=='Windows'"
+        "pywin32; platform_system=='Windows'",
     ],
     entry_points={
         "gui_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     long_description_content_type="text/markdown",
     exclude_package_data={'': ['.gitignore']},
     # Using this instead of MANIFEST.in - https://pypi.org/project/setuptools-git/
+    python_requires=">=3.7",
     setup_requires=['setuptools-git'],
     install_requires=[
         "pandas",

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -2,7 +2,7 @@ import pandas as pd
 import numpy as np
 import time
 import os
-from PyQt5 import QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets
 
 
 def generate_string_data(rows, cols, length=5):


### PR DESCRIPTION
FIxes #168 
Fixes #116 

Hi, thanks for making PandasGui! I plan to use it in an application I'm building with Pyside6 and thought I would help out with the move to using QtPy bindings.

Changes made:
* `import PyQt5` -> `import qtpy`
* `from PyQt5` -> `from qtpy`
* `pyqtSignal` -> `Signal`
* `pyqtSlot` -> `Slot`
* Removed PyQt5 etc. from `requirements.txt` and `setup.py`. Replaced with qtpy. Note, users must ensure they have PyQt/PySide installed ([see the qtpy docs](https://github.com/spyder-ide/qtpy#requirements)). If using PyQt, users must also install PyQtWebEngineWidgets separately (PySide has this built-in).

A couple of things I'm not sure about:
* `PandasGui.utility.fix_pyqt` - will this fix work for both pyqt and pyside?
* `PandasGui.utility.fix_ipython` - if using `ipython`, sets `ipython.magic("gui qt5")`. Would `ipython.magic("gui qt6")` work for PyQt6/PySide6?

I ran the tests locally and they seems to run okay, although there were a few warnings (see 
[test-output.txt](https://github.com/adamerose/PandasGUI/files/7952245/test-output.txt)

