### PR TITLE
support for xpt file

### DIFF
--- a/pandasgui/gui.py
+++ b/pandasgui/gui.py
@@ -330,7 +330,7 @@ class PandasGui(QtWidgets.QMainWindow):
 
     def import_dialog(self):
         dialog = QtWidgets.QFileDialog()
-        paths, _ = dialog.getOpenFileNames(filter="*.csv *.xlsx *.parquet *.json")
+        paths, _ = dialog.getOpenFileNames(filter="*.csv *.xlsx *.parquet *.json *.xpt")
         for path in paths:
             self.store.import_file(path)
 

--- a/pandasgui/run_with_args.py
+++ b/pandasgui/run_with_args.py
@@ -11,11 +11,13 @@ def main():
         if file_paths:
             file_dataframes = {}
             for path in file_paths:
-                if os.path.isfile(path) and (path.endswith('.csv') or path.endswith('.pkl')):
+                if os.path.isfile(path) and (path.endswith('.csv') or path.endswith('.pkl') or path.endswith('.xpt')):
                     if path.endswith('.csv') :
                         df = pd.read_csv(path)
                     if path.endswith('.pkl'):
                         df = pd.read_pickle(path)
+                    if path.endswith('.xpt') :
+                        df = pd.read_sas(path, encoding='utf-8')
                     filename = os.path.split(path)[1]
                     file_dataframes[filename] = df
             show(**file_dataframes)

--- a/pandasgui/store.py
+++ b/pandasgui/store.py
@@ -834,6 +834,10 @@ class PandasGuiStore:
             filename = os.path.split(path)[1].split('.csv')[0]
             df = pd.read_csv(path, engine='python')
             self.add_dataframe(df, filename)
+        elif path.endswith(".xpt"):
+            filename = os.path.split(path)[1].split('.xpt')[0]
+            df = pd.read_sas(path, encoding='utf-8')
+            self.add_dataframe(df, filename)
         elif path.endswith(".xlsx"):
             filename = os.path.split(path)[1].split('.csv')[0]
             df_dict = pd.read_excel(path, sheet_name=None)
@@ -856,7 +860,7 @@ class PandasGuiStore:
             df = pd.read_pickle(path)
             self.add_dataframe(df, filename)
         else:
-            logger.warning("Can only import csv / xlsx / parquet. Invalid file: " + path)
+            logger.warning("Can only import csv / xlsx / parquet/ xpt. Invalid file: " + path)
 
     def get_dataframes(self, names: Union[None, str, list, int] = None):
         if type(names) == str:


### PR DESCRIPTION
The SAS transport format (xpt) is a open format, as is required for submission of clinical and nonclinical data to the FDA.
There are not many tools that support xpt file. At least, I don't know any open source tool (GUI) where you can open the xpt file and view the content. It would very helpful if PandasGUI support xpt file system. pandas package already have read_sas() function which convert xpt to pandas dataframe. Which makes it easy to integrate into PandasGUI. I was able to create executable file from PandasGUI, so this application can be distributed to non-programmer and they can open and view xpt file. 