### PR TITLE
Fixing problems with IPython >= 9

### DIFF
--- a/pandasgui/utility.py
+++ b/pandasgui/utility.py
@@ -108,7 +108,10 @@ def fix_ipython():
     from IPython import get_ipython
     ipython = get_ipython()
     if ipython is not None:
-        ipython.magic("gui qt5")
+        try:
+            ipython.magic("gui qt5")
+        except AttributeError:
+            ipython.run_line_magic("gui", "qt5")
 
 
 def in_interactive_console():


### PR DESCRIPTION
ipython.magic() was deprecated for long time and is removed in IPython 9,
ipython.run_line_magic should be used instead. To minimize changes, trying magic()  first and then retrying run_line_magic() on failure