### PR TITLE
Fix Bokeh version check for compatibility

### DIFF
--- a/pandasgui/utility.py
+++ b/pandasgui/utility.py
@@ -470,7 +470,7 @@ def get_figure_type(fig) -> typing.Literal[
     # Bokeh
     try:
         import bokeh.plotting
-        if int(bokeh.__version.split(".")[0]) < 3:
+        if int(bokeh.__version__.split(".")[0]) < 3:
             if issubclass(type(fig), bokeh.plotting.Figure):  # Figure for Bokeh < 3.0.0
                 return "bokeh"
         else:


### PR DESCRIPTION
Would not run due to error:

"AttributeError: module 'bokeh' has no attribute '__version'. Did you mean: '__version__'?"

Updated utiliy.py to use __version__