### PR TITLE
Remove runtime pkg_resources usage

### DIFF
--- a/pandasgui/__init__.py
+++ b/pandasgui/__init__.py
@@ -1,6 +1,13 @@
 # Set version
-from pkg_resources import get_distribution
-__version__ = get_distribution('pandasgui').version
+try:
+    from importlib.metadata import PackageNotFoundError, version
+except ImportError:
+    from importlib_metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("pandasgui")
+except PackageNotFoundError:
+    __version__ = "0.2.15"
 
 # Logger config
 import logging

--- a/pandasgui/constants.py
+++ b/pandasgui/constants.py
@@ -1,7 +1,8 @@
 import os
 import sys
+from pathlib import Path
+
 from appdirs import user_data_dir
-import pkg_resources
 
 LOCAL_DATA_DIR = os.path.join(user_data_dir(), "pandasgui")
 LOCAL_DATASET_DIR = os.path.join(LOCAL_DATA_DIR, "dataset_files")
@@ -9,8 +10,9 @@ LOCAL_DATASET_DIR = os.path.join(LOCAL_DATA_DIR, "dataset_files")
 os.makedirs(LOCAL_DATA_DIR, exist_ok=True)
 os.makedirs(LOCAL_DATASET_DIR, exist_ok=True)
 
-PANDASGUI_ICON_PATH = pkg_resources.resource_filename(__name__, "resources/images/icon.png")
-PANDASGUI_ICON_PATH_ICO = pkg_resources.resource_filename(__name__, "resources/images/icon.ico")
+RESOURCE_IMAGE_DIR = Path(__file__).resolve().parent / "resources" / "images"
+PANDASGUI_ICON_PATH = str(RESOURCE_IMAGE_DIR / "icon.png")
+PANDASGUI_ICON_PATH_ICO = str(RESOURCE_IMAGE_DIR / "icon.ico")
 
 if sys.platform == "win32":
     SHORTCUT_PATH = os.path.join(os.getenv('APPDATA'), 'Microsoft/Windows/Start Menu/Programs/PandasGUI.lnk', )

--- a/pandasgui/widgets/find_toolbar.py
+++ b/pandasgui/widgets/find_toolbar.py
@@ -1,7 +1,7 @@
+from pathlib import Path
 import re
 import time
 
-import pkg_resources
 from PyQt5 import QtCore, QtGui, QtWidgets
 from PyQt5.QtCore import Qt
 
@@ -24,7 +24,9 @@ class FindToolbar(QtWidgets.QToolBar):
         # Current QModelIndex
         self.search_selection = None
         self.match_flags = {"regex": False, "case": False, "whole word": False}
-        self.image_folder = "../resources/images"
+        self.image_folder = (
+            Path(__file__).resolve().parents[1] / "resources" / "images"
+        )
 
         # main toolbar widget
         find_toolbar_widget = QtWidgets.QWidget()
@@ -42,10 +44,7 @@ class FindToolbar(QtWidgets.QToolBar):
         # add match modification
 
         # add match case button
-        match_case_icon_raw_path = self.image_folder + "/case-sensitive.svg"
-        match_case_icon_path = pkg_resources.resource_filename(
-            __name__, match_case_icon_raw_path
-        )
+        match_case_icon_path = str(self.image_folder / "case-sensitive.svg")
         match_case_icon = QtGui.QIcon(match_case_icon_path)
         self.match_case_button = QtWidgets.QToolButton(self.find_textbox)
         self.match_case_button.setIcon(match_case_icon)
@@ -56,8 +55,7 @@ class FindToolbar(QtWidgets.QToolBar):
         self.find_textbox.add_button(self.match_case_button)
 
         # add match regex button
-        regex_icon_raw_path = self.image_folder + "/regex.svg"
-        regex_icon_path = pkg_resources.resource_filename(__name__, regex_icon_raw_path)
+        regex_icon_path = str(self.image_folder / "regex.svg")
         regex_icon = QtGui.QIcon(regex_icon_path)
         self.match_regex_button = QtWidgets.QToolButton(self.find_textbox)
         self.match_regex_button.setIcon(regex_icon)
@@ -68,10 +66,7 @@ class FindToolbar(QtWidgets.QToolBar):
         self.find_textbox.add_button(self.match_regex_button)
 
         # add match exactly button
-        match_exactly_icon_raw_path = self.image_folder + "/match-exactly.svg"
-        match_exactly_icon_path = pkg_resources.resource_filename(
-            __name__, match_exactly_icon_raw_path
-        )
+        match_exactly_icon_path = str(self.image_folder / "match-exactly.svg")
         whole_word_icon = QtGui.QIcon(match_exactly_icon_path)
         self.match_exactly_button = QtWidgets.QToolButton(self.find_textbox)
         self.match_exactly_button.setIcon(whole_word_icon)
@@ -91,9 +86,7 @@ class FindToolbar(QtWidgets.QToolBar):
 
         # go to next match
         previous_match_button = QtWidgets.QPushButton()
-        up_arrow_icon_raw_path = self.image_folder + "/arrow-up.svg"
-        up_arrow_icon_path = pkg_resources.resource_filename(
-            __name__, up_arrow_icon_raw_path)
+        up_arrow_icon_path = str(self.image_folder / "arrow-up.svg")
         up_arrow_icon = QtGui.QIcon(up_arrow_icon_path)
         previous_match_button.setIcon(up_arrow_icon)
         previous_match_button.setToolTip("Previous match")
@@ -102,10 +95,7 @@ class FindToolbar(QtWidgets.QToolBar):
 
         # go to previous match
         next_match_button = QtWidgets.QPushButton()
-        down_arrow_icon_raw_path = self.image_folder + "/arrow-down.svg"
-        down_arrow_icon_path = pkg_resources.resource_filename(
-            __name__, down_arrow_icon_raw_path
-        )
+        down_arrow_icon_path = str(self.image_folder / "arrow-down.svg")
         down_arrow_icon = QtGui.QIcon(down_arrow_icon_path)
         next_match_button.setIcon(down_arrow_icon)
         next_match_button.setToolTip("Next match")
@@ -114,10 +104,7 @@ class FindToolbar(QtWidgets.QToolBar):
 
         # close find toolbar
         close_find_button = QtWidgets.QPushButton()
-        cancel_icon_raw_path = self.image_folder + "/close.svg"
-        cancel_icon_path = pkg_resources.resource_filename(
-            __name__, cancel_icon_raw_path
-        )
+        cancel_icon_path = str(self.image_folder / "close.svg")
         close_icon = QtGui.QIcon(cancel_icon_path)
         close_find_button.setIcon(close_icon)
         close_find_button.setToolTip("Close Find Bar")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ PyQt5-sip
 PyQtWebEngine
 plotly
 wordcloud
-setuptools
+importlib-metadata; python_version<"3.8"
 appdirs
 pynput
 IPython

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "PyQtWebEngine",
         "plotly",
         "wordcloud",
-        "setuptools",
+        "importlib-metadata; python_version<'3.8'",
         "appdirs",
         "pynput",
         "IPython",


### PR DESCRIPTION
Fixes #262.

## Summary
- Replace the runtime `pkg_resources` version lookup with `importlib.metadata`.
- Resolve bundled icon paths relative to the package files instead of `pkg_resources.resource_filename()`.
- Remove `setuptools` from runtime requirements and add the metadata backport for Python 3.7.

## Validation
- Not run locally.